### PR TITLE
feat: add AI routes, radio routes, and AI page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,9 +11,11 @@ import FunPage from './pages/FunPage'
 import CartPage from './pages/CartPage'
 import CheckoutPage from './pages/CheckoutPage'
 import OrderStatusPage from './pages/OrderStatusPage'
+import AiPage from './pages/AiPage'
 import LoadingScreen from './components/LoadingScreen'
 import BottomNav from './components/BottomNav'
 import Header from './components/Header'
+import RadioPlayer from './components/RadioPlayer'
 
 declare global {
   interface Window {
@@ -49,6 +51,7 @@ export default function App() {
           <Route path="/profile" element={<ProfilePage />} />
           <Route path="/bonuses" element={<BonusesPage />} />
           <Route path="/fun" element={<FunPage />} />
+          <Route path="/ai" element={<AiPage />} />
           <Route path="/cart" element={<CartPage />} />
           <Route path="/checkout" element={<CheckoutPage />} />
           <Route path="/orders/:id" element={<OrderStatusPage />} />
@@ -56,6 +59,7 @@ export default function App() {
         </Routes>
       </main>
       <BottomNav />
+      <RadioPlayer />
     </div>
   )
 }

--- a/client/src/components/BottomNav.tsx
+++ b/client/src/components/BottomNav.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx'
 const tabs = [
   { path: '/menu',    emoji: '☕', label: 'Меню' },
   { path: '/cart',    emoji: '🛒', label: 'Кошик' },
-  { path: '/fun',     emoji: '🎮', label: 'Fun' },
+  { path: '/ai',      emoji: '✨', label: 'AI' },
   { path: '/bonuses', emoji: '🎡', label: 'Бонуси' },
   { path: '/profile', emoji: '👤', label: 'Я' },
 ]

--- a/client/src/components/RadioPlayer.tsx
+++ b/client/src/components/RadioPlayer.tsx
@@ -1,0 +1,163 @@
+import { useState, useEffect, useRef } from 'react'
+import { radioApi } from '../lib/api'
+
+interface RadioTrack {
+  id: number
+  title: string
+  artist: string
+  url: string
+  duration: number
+  genre: string
+}
+
+interface NowResponse {
+  currentTrack: RadioTrack | null
+  position: number
+  serverTime: number
+}
+
+export default function RadioPlayer() {
+  const [track, setTrack] = useState<RadioTrack | null>(null)
+  const [playing, setPlaying] = useState(false)
+  const [expanded, setExpanded] = useState(false)
+  const [visible, setVisible] = useState(false)
+  const audioRef = useRef<HTMLAudioElement | null>(null)
+  const syncIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  useEffect(() => {
+    radioApi.now()
+      .then(r => {
+        const data = r.data as NowResponse
+        if (data.currentTrack) {
+          setTrack(data.currentTrack)
+          setVisible(true)
+        }
+      })
+      .catch(() => { /* no tracks available */ })
+  }, [])
+
+  const syncAudio = async () => {
+    try {
+      const r = await radioApi.now()
+      const data = r.data as NowResponse
+      if (!data.currentTrack) return
+
+      const audio = audioRef.current
+      if (!audio) return
+
+      if (data.currentTrack.id !== track?.id) {
+        setTrack(data.currentTrack)
+        audio.src = data.currentTrack.url
+        audio.currentTime = data.position
+        if (playing) audio.play().catch(() => {})
+      } else {
+        const drift = Math.abs(audio.currentTime - data.position)
+        if (drift > 3) {
+          audio.currentTime = data.position
+        }
+      }
+    } catch { /* ignore */ }
+  }
+
+  const handlePlay = async () => {
+    if (!track) return
+    const audio = audioRef.current
+    if (!audio) return
+
+    if (!audio.src || audio.src === window.location.href) {
+      const r = await radioApi.now()
+      const data = r.data as NowResponse
+      audio.src = track.url
+      audio.currentTime = data.position
+    }
+
+    try {
+      await audio.play()
+      setPlaying(true)
+      syncIntervalRef.current = setInterval(syncAudio, 30000)
+    } catch { /* autoplay blocked */ }
+  }
+
+  const handlePause = () => {
+    audioRef.current?.pause()
+    setPlaying(false)
+    if (syncIntervalRef.current) {
+      clearInterval(syncIntervalRef.current)
+      syncIntervalRef.current = null
+    }
+  }
+
+  const handleToggle = () => {
+    if (playing) handlePause()
+    else handlePlay()
+  }
+
+  useEffect(() => {
+    return () => {
+      if (syncIntervalRef.current) clearInterval(syncIntervalRef.current)
+    }
+  }, [])
+
+  if (!visible || !track) return null
+
+  return (
+    <>
+      <audio ref={audioRef} preload="none" />
+
+      {/* Floating mini player */}
+      <div
+        className="fixed bottom-20 right-4 z-50"
+        style={{ filter: 'drop-shadow(0 4px 12px rgba(0,0,0,0.15))' }}
+      >
+        {expanded ? (
+          <div className="bg-white rounded-2xl p-4 w-64 border border-gray-100">
+            <div className="flex items-center justify-between mb-3">
+              <span className="text-xs text-gray-400 font-medium">PerkUp Radio</span>
+              <button
+                onClick={() => setExpanded(false)}
+                className="text-gray-400 hover:text-gray-600 text-lg leading-none"
+              >
+                ×
+              </button>
+            </div>
+            <div className="mb-3">
+              <div className="font-semibold text-gray-800 text-sm truncate">{track.title}</div>
+              <div className="text-xs text-gray-400 truncate">{track.artist}</div>
+            </div>
+            <div className="flex items-center justify-center gap-4">
+              <button
+                onClick={handleToggle}
+                className="w-10 h-10 rounded-full bg-coffee-600 text-white flex items-center justify-center text-lg"
+              >
+                {playing ? '⏸' : '▶'}
+              </button>
+            </div>
+            {playing && (
+              <div className="mt-3 flex items-center gap-1.5">
+                {[0, 1, 2, 3].map(i => (
+                  <div
+                    key={i}
+                    className="w-1 bg-coffee-400 rounded-full animate-pulse"
+                    style={{
+                      height: `${8 + (i % 3) * 4}px`,
+                      animationDelay: `${i * 0.15}s`,
+                    }}
+                  />
+                ))}
+                <span className="text-xs text-gray-400 ml-1">Грає зараз</span>
+              </div>
+            )}
+          </div>
+        ) : (
+          <button
+            onClick={() => setExpanded(true)}
+            className="w-12 h-12 rounded-full bg-coffee-600 text-white flex items-center justify-center shadow-lg text-xl"
+            title="PerkUp Radio"
+          >
+            {playing ? '\uD83C\uDFB5' : '\uD83C\uDFB6'}
+          </button>
+        )}
+      </div>
+    </>
+  )
+}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -88,3 +88,23 @@ export const loyaltyApi = {
 // Media
 export const mediaUrl = (fileId: string) =>
   `${BASE_URL}/api/media/${fileId}`
+
+// AI
+export const aiApi = {
+  weatherMenu: () => api.get('/api/ai/weather-menu'),
+  cardOfDay: () => api.get('/api/ai/card-of-day'),
+  coffeeFact: () => api.get('/api/ai/coffee-fact'),
+  moodMenu: (mood: string, locationSlug?: string) =>
+    api.post('/api/ai/mood-menu', { mood, locationSlug }),
+  dailyChallenge: () => api.get('/api/ai/daily-challenge'),
+  claimChallenge: () => api.post('/api/ai/daily-challenge/claim'),
+}
+
+// Radio
+export const radioApi = {
+  playlist: () => api.get('/api/radio/playlist'),
+  now: () => api.get('/api/radio/now'),
+  addTrack: (data: { fileId: string; title: string; url: string; artist?: string; duration?: number; genre?: string }) =>
+    api.post('/api/radio/add-track', data),
+  setGenre: (genre: string) => api.post('/api/radio/user-genre', { genre }),
+}

--- a/client/src/pages/AiPage.tsx
+++ b/client/src/pages/AiPage.tsx
@@ -1,0 +1,238 @@
+import { useState, useEffect } from 'react'
+import { aiApi } from '../lib/api'
+import { useLocationStore } from '../stores/location'
+
+interface WeatherData {
+  temp: number
+  description: string
+  recommendation: string
+}
+
+interface CardOfDay {
+  drinkName: string
+  description: string
+}
+
+interface CoffeeFact {
+  fact: string
+}
+
+interface MoodResult {
+  recommendation: string
+  matchedDrink: string | null
+}
+
+interface DailyChallenge {
+  challenge: string
+  points: number
+  claimed: boolean
+  dateKey: string
+}
+
+export default function AiPage() {
+  const { activeLocation } = useLocationStore()
+
+  const [weather, setWeather] = useState<WeatherData | null>(null)
+  const [card, setCard] = useState<CardOfDay | null>(null)
+  const [fact, setFact] = useState<CoffeeFact | null>(null)
+  const [challenge, setChallenge] = useState<DailyChallenge | null>(null)
+
+  const [mood, setMood] = useState('')
+  const [moodResult, setMoodResult] = useState<MoodResult | null>(null)
+  const [moodLoading, setMoodLoading] = useState(false)
+
+  const [claimLoading, setClaimLoading] = useState(false)
+  const [claimMsg, setClaimMsg] = useState('')
+
+  const [loadingWeather, setLoadingWeather] = useState(true)
+  const [loadingCard, setLoadingCard] = useState(true)
+  const [loadingFact, setLoadingFact] = useState(true)
+  const [loadingChallenge, setLoadingChallenge] = useState(true)
+
+  useEffect(() => {
+    aiApi.weatherMenu()
+      .then(r => setWeather(r.data))
+      .catch(() => setWeather(null))
+      .finally(() => setLoadingWeather(false))
+
+    aiApi.cardOfDay()
+      .then(r => setCard(r.data))
+      .catch(() => setCard(null))
+      .finally(() => setLoadingCard(false))
+
+    aiApi.coffeeFact()
+      .then(r => setFact(r.data))
+      .catch(() => setFact(null))
+      .finally(() => setLoadingFact(false))
+
+    aiApi.dailyChallenge()
+      .then(r => setChallenge(r.data))
+      .catch(() => setChallenge(null))
+      .finally(() => setLoadingChallenge(false))
+  }, [])
+
+  const handleMoodSubmit = async () => {
+    if (!mood.trim()) return
+    setMoodLoading(true)
+    setMoodResult(null)
+    try {
+      const res = await aiApi.moodMenu(mood.trim(), activeLocation?.slug)
+      setMoodResult(res.data)
+    } catch {
+      setMoodResult({ recommendation: 'Не вдалося отримати рекомендацію', matchedDrink: null })
+    } finally {
+      setMoodLoading(false)
+    }
+  }
+
+  const handleClaim = async () => {
+    if (!challenge || challenge.claimed || claimLoading) return
+    setClaimLoading(true)
+    setClaimMsg('')
+    try {
+      const res = await aiApi.claimChallenge()
+      setClaimMsg('+' + res.data.pointsAdded + ' балів зараховано!')
+      setChallenge(prev => prev ? { ...prev, claimed: true } : prev)
+    } catch (e: any) {
+      setClaimMsg(e?.response?.data?.error || 'Помилка')
+    } finally {
+      setClaimLoading(false)
+    }
+  }
+
+  const MOODS = ['😊 Радісний', '😴 Сонний', '💪 Енергійний', '😌 Спокійний', '🥶 Холодно', '🔥 Жарко']
+
+  return (
+    <div className="p-4 space-y-4 pb-24">
+      <h1 className="text-2xl font-bold text-coffee-700">✨ AI-куточок</h1>
+
+      {/* Weather Banner */}
+      <div className="bg-gradient-to-br from-blue-500 to-blue-700 rounded-2xl p-4 text-white shadow">
+        <div className="text-xs font-medium opacity-80 mb-1">Бровари, зараз</div>
+        {loadingWeather ? (
+          <div className="animate-pulse h-16 bg-white/20 rounded-xl" />
+        ) : weather ? (
+          <>
+            <div className="text-3xl font-bold mb-1">{weather.temp}°C</div>
+            <div className="text-sm opacity-90 capitalize mb-3">{weather.description}</div>
+            {weather.recommendation && (
+              <div className="bg-white/20 rounded-xl p-3 text-sm leading-relaxed">
+                {weather.recommendation}
+              </div>
+            )}
+          </>
+        ) : (
+          <div className="text-sm opacity-80">Не вдалося завантажити погоду</div>
+        )}
+      </div>
+
+      {/* Card of Day */}
+      <div className="bg-white rounded-2xl p-4 shadow border border-gray-100">
+        <div className="text-xs text-coffee-500 font-semibold uppercase tracking-wider mb-2">☕ Кава дня</div>
+        {loadingCard ? (
+          <div className="space-y-2">
+            <div className="animate-pulse h-5 bg-gray-100 rounded w-1/2" />
+            <div className="animate-pulse h-16 bg-gray-100 rounded" />
+          </div>
+        ) : card ? (
+          <>
+            <div className="font-bold text-coffee-800 text-lg mb-2">{card.drinkName}</div>
+            <div className="text-gray-600 text-sm leading-relaxed italic">{card.description}</div>
+          </>
+        ) : (
+          <div className="text-gray-400 text-sm">Недоступно</div>
+        )}
+      </div>
+
+      {/* Coffee Fact */}
+      <div className="bg-amber-50 border border-amber-200 rounded-2xl p-4">
+        <div className="text-xs text-amber-700 font-semibold uppercase tracking-wider mb-2">🌿 Факт дня</div>
+        {loadingFact ? (
+          <div className="animate-pulse h-10 bg-amber-100 rounded" />
+        ) : fact ? (
+          <div className="text-gray-700 text-sm leading-relaxed">{fact.fact}</div>
+        ) : (
+          <div className="text-gray-400 text-sm">Недоступно</div>
+        )}
+      </div>
+
+      {/* Mood Picker */}
+      <div className="bg-white rounded-2xl p-4 shadow border border-gray-100">
+        <div className="text-xs text-coffee-500 font-semibold uppercase tracking-wider mb-3">🎭 Настрій → Напій</div>
+        <div className="flex flex-wrap gap-2 mb-3">
+          {MOODS.map(m => (
+            <button
+              key={m}
+              onClick={() => setMood(m)}
+              className={`px-3 py-1.5 rounded-full text-sm border transition-colors ${
+                mood === m
+                  ? 'bg-coffee-600 text-white border-coffee-600'
+                  : 'bg-gray-50 text-gray-600 border-gray-200 hover:border-coffee-300'
+              }`}
+            >
+              {m}
+            </button>
+          ))}
+        </div>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={mood}
+            onChange={e => setMood(e.target.value)}
+            placeholder="або опишіть свій стан..."
+            className="flex-1 border border-gray-200 rounded-xl px-3 py-2 text-sm focus:outline-none focus:border-coffee-400"
+            onKeyDown={e => { if (e.key === 'Enter') handleMoodSubmit() }}
+          />
+          <button
+            onClick={handleMoodSubmit}
+            disabled={moodLoading || !mood.trim()}
+            className="px-4 py-2 bg-coffee-600 text-white rounded-xl text-sm disabled:opacity-50 whitespace-nowrap"
+          >
+            {moodLoading ? '...' : 'Підібрати'}
+          </button>
+        </div>
+        {moodResult && (
+          <div className="mt-3 bg-coffee-50 rounded-xl p-3 text-sm text-gray-700 leading-relaxed">
+            {moodResult.matchedDrink && (
+              <div className="font-semibold text-coffee-700 mb-1">☕ {moodResult.matchedDrink}</div>
+            )}
+            {moodResult.recommendation}
+          </div>
+        )}
+      </div>
+
+      {/* Daily Challenge */}
+      <div className="bg-gradient-to-br from-purple-500 to-indigo-600 rounded-2xl p-4 text-white shadow">
+        <div className="text-xs font-medium opacity-80 mb-2">🏆 Щоденний челендж</div>
+        {loadingChallenge ? (
+          <div className="animate-pulse h-12 bg-white/20 rounded-xl" />
+        ) : challenge ? (
+          <>
+            <div className="text-sm leading-relaxed mb-3">{challenge.challenge}</div>
+            <div className="flex items-center justify-between">
+              <span className="text-xs opacity-80">+{challenge.points} балів за виконання</span>
+              {challenge.claimed ? (
+                <span className="bg-white/30 px-3 py-1.5 rounded-xl text-xs font-semibold">
+                  ✓ Виконано
+                </span>
+              ) : (
+                <button
+                  onClick={handleClaim}
+                  disabled={claimLoading}
+                  className="bg-white text-purple-700 px-3 py-1.5 rounded-xl text-xs font-semibold disabled:opacity-60"
+                >
+                  {claimLoading ? '...' : 'Отримати бали'}
+                </button>
+              )}
+            </div>
+            {claimMsg && (
+              <div className="mt-2 text-xs bg-white/20 rounded-lg px-3 py-1.5">{claimMsg}</div>
+            )}
+          </>
+        ) : (
+          <div className="text-sm opacity-80">Недоступно</div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -78,6 +78,7 @@ model User {
   notifMorning        Boolean   @default(true)
   notifPromo          Boolean   @default(true)
   onboardingDone      Boolean   @default(false)
+  radioGenre          String?
   isActive            Boolean   @default(true)
   createdAt           DateTime  @default(now())
   updatedAt           DateTime  @updatedAt

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -17,6 +17,8 @@ import reviewRoutes from './routes/reviews'
 import notificationsRoutes from './routes/notifications'
 import healthRoutes from './routes/health'
 import posterWebhookRoutes from './routes/webhooks/poster'
+import aiRoutes from './routes/ai'
+import radioRoutes from './routes/radio'
 import { schedulePosterSync, startPosterSyncWorker } from './workers/posterSync'
 import { scheduleReminderJobs, startReminderWorker } from './workers/reminders'
 import { syncAllLocations } from './services/poster'
@@ -42,6 +44,8 @@ async function bootstrap() {
   await app.register(reviewRoutes,        { prefix: '/api/reviews' })
   await app.register(notificationsRoutes, { prefix: '/api/notifications' })
   await app.register(posterWebhookRoutes, { prefix: '/webhooks/poster' })
+  await app.register(aiRoutes,            { prefix: '/api/ai' })
+  await app.register(radioRoutes,         { prefix: '/api/radio' })
   app.setErrorHandler((error, _req, reply) => {
     if (error.statusCode === 429) return reply.status(429).send({ success: false, error: 'Too many requests' })
     if (error.statusCode && error.statusCode < 500) return reply.status(error.statusCode).send({ success: false, error: error.message })

--- a/server/src/routes/ai.ts
+++ b/server/src/routes/ai.ts
@@ -1,0 +1,235 @@
+import { FastifyInstance } from 'fastify'
+import { redisCache } from '../lib/redis'
+import { prisma } from '../lib/prisma'
+
+const WEATHER_API_KEY = process.env.OPENWEATHER_API_KEY || ''
+const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY || ''
+const BROVARY_LAT = '50.5167'
+const BROVARY_LON = '30.7833'
+const CLAUDE_MODEL = 'claude-3-5-haiku-20241022'
+const CACHE_12H = 43200
+const CACHE_1H = 3600
+
+interface ClaudeResponse {
+  content?: Array<{ text?: string }>
+}
+
+interface WeatherMain {
+  temp?: number
+}
+
+interface WeatherCondition {
+  description?: string
+}
+
+interface WeatherResponse {
+  main?: WeatherMain
+  weather?: WeatherCondition[]
+}
+
+async function callClaude(prompt: string, maxTokens = 300): Promise<string> {
+  if (!ANTHROPIC_API_KEY) return ''
+  try {
+    const res = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'x-api-key': ANTHROPIC_API_KEY,
+        'anthropic-version': '2023-06-01',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: CLAUDE_MODEL,
+        max_tokens: maxTokens,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    })
+    const data = await res.json() as ClaudeResponse
+    return (data.content?.[0]?.text || '').trim()
+  } catch (err) {
+    console.error('Claude API error:', err)
+    return ''
+  }
+}
+
+function todayKey(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+export default async function aiRoutes(app: FastifyInstance) {
+  async function optionalAuth(req: any, _reply: any) {
+    try { await req.jwtVerify() } catch { /* guest */ }
+  }
+
+  async function requireAuth(req: any, reply: any) {
+    try { await req.jwtVerify() } catch {
+      return reply.status(401).send({ success: false, error: 'Unauthorized' })
+    }
+  }
+
+  // GET /api/ai/weather-menu
+  app.get('/weather-menu', async (_req, reply) => {
+    const cacheKey = 'ai:weather-menu:' + todayKey()
+    const cached = await redisCache.get(cacheKey)
+    if (cached) return reply.send({ success: true, ...JSON.parse(cached) })
+
+    let temp = 0
+    let description = 'clear'
+    try {
+      const wRes = await fetch(
+        `https://api.openweathermap.org/data/2.5/weather?lat=${BROVARY_LAT}&lon=${BROVARY_LON}&appid=${WEATHER_API_KEY}&units=metric&lang=en`
+      )
+      const wData = await wRes.json() as WeatherResponse
+      temp = Math.round(wData.main?.temp ?? 0)
+      description = wData.weather?.[0]?.description || 'clear'
+    } catch (err) {
+      console.error('Weather fetch error:', err)
+    }
+
+    const weatherText = `${temp}\u00B0C, ${description}`
+    const prompt = `You are a friendly barista at PerkUp coffee shop in Brovary, Ukraine.
+Current weather: ${weatherText}.
+Recommend ONE coffee or drink from: espresso, cappuccino, latte, flat white, americano, cold brew, hot chocolate, matcha latte.
+Write 2-3 sentences in English. Be warm and weather-aware. No lists, no bullet points.`
+
+    const recommendation = await callClaude(prompt, 200)
+
+    const payload = { temp, description, recommendation }
+    await redisCache.set(cacheKey, JSON.stringify(payload), 'EX', CACHE_1H)
+    return reply.send({ success: true, ...payload })
+  })
+
+  // GET /api/ai/card-of-day
+  app.get('/card-of-day', async (_req, reply) => {
+    const cacheKey = 'ai:card-of-day:' + todayKey()
+    const cached = await redisCache.get(cacheKey)
+    if (cached) return reply.send({ success: true, ...JSON.parse(cached) })
+
+    const prompt = `You are a poetic barista. Write a short poetic description (3-4 sentences) of today's "Coffee of the Day" at PerkUp cafe in Brovary.
+Make it atmospheric, warm, and inspiring. Start with the drink name on the first line (2-4 words, creative), then write the poetic description.
+Write in English. No hashtags, no markdown.`
+
+    const text = await callClaude(prompt, 280)
+    const lines = text.split('\n').filter(l => l.trim().length > 0)
+    const drinkName = (lines[0] || 'Morning Blend').replace(/[*_#]/g, '').trim()
+    const descriptionText = lines.slice(1).join(' ').trim() || text
+
+    const payload = { drinkName, description: descriptionText }
+    await redisCache.set(cacheKey, JSON.stringify(payload), 'EX', CACHE_12H)
+    return reply.send({ success: true, ...payload })
+  })
+
+  // GET /api/ai/coffee-fact
+  app.get('/coffee-fact', async (_req, reply) => {
+    const cacheKey = 'ai:coffee-fact:' + todayKey()
+    const cached = await redisCache.get(cacheKey)
+    if (cached) return reply.send({ success: true, ...JSON.parse(cached) })
+
+    const prompt = `Share ONE interesting, surprising or little-known fact about coffee.
+Write 1-2 sentences in English. Make it engaging and educational. No lists, no bullet points, no markdown.`
+
+    const fact = await callClaude(prompt, 150)
+    const payload = { fact }
+    await redisCache.set(cacheKey, JSON.stringify(payload), 'EX', CACHE_12H)
+    return reply.send({ success: true, ...payload })
+  })
+
+  // POST /api/ai/mood-menu
+  app.post('/mood-menu', { preHandler: requireAuth }, async (req: any, reply) => {
+    const body = req.body as { mood?: string; locationSlug?: string }
+    const { mood, locationSlug } = body
+
+    if (!mood || typeof mood !== 'string') {
+      return reply.status(400).send({ success: false, error: 'mood required' })
+    }
+
+    let menuItems: string[] = []
+    if (locationSlug && typeof locationSlug === 'string') {
+      const products = await prisma.product.findMany({
+        where: { location: { slug: locationSlug }, isAvailable: true },
+        select: { name: true },
+        take: 25,
+      })
+      menuItems = products.map(p => p.name)
+    }
+
+    const menuStr = menuItems.length > 0
+      ? 'Available drinks: ' + menuItems.join(', ')
+      : 'Available drinks: espresso, cappuccino, latte, flat white, americano, cold brew, hot chocolate'
+
+    const prompt = `You are a friendly PerkUp barista. A customer says they feel: "${mood}".
+${menuStr}.
+Recommend ONE specific drink from the list and explain in 2 sentences why it suits their mood.
+Write in English. Be warm and personal. No lists.`
+
+    const recommendation = await callClaude(prompt, 200)
+    const matched = menuItems.find(name =>
+      recommendation.toLowerCase().includes(name.toLowerCase())
+    )
+
+    return reply.send({ success: true, recommendation, matchedDrink: matched || null })
+  })
+
+  // GET /api/ai/daily-challenge
+  app.get('/daily-challenge', { preHandler: optionalAuth }, async (req: any, reply) => {
+    const dateKey = todayKey()
+    const cacheKey = 'ai:challenge:' + dateKey
+
+    let challenge = await redisCache.get(cacheKey)
+    if (!challenge) {
+      const prompt = `Create ONE fun daily coffee challenge for PerkUp cafe customers.
+Examples: "Try your coffee without sugar today", "Ask the barista for their secret favorite drink", "Take a mindful sip and describe the flavor".
+Write ONE sentence in English. Be fun, positive, and achievable. No lists.`
+      challenge = await callClaude(prompt, 100)
+      if (!challenge) challenge = 'Try your coffee at a slower pace today and enjoy every sip!'
+      await redisCache.set(cacheKey, challenge, 'EX', CACHE_12H)
+    }
+
+    const POINTS_FOR_CHALLENGE = 5
+    let claimed = false
+
+    if (req.user?.id) {
+      const claimKey = 'ai:challenge-claimed:' + dateKey + ':' + req.user.id
+      claimed = !!(await redisCache.get(claimKey))
+    }
+
+    return reply.send({ success: true, challenge, points: POINTS_FOR_CHALLENGE, claimed, dateKey })
+  })
+
+  // POST /api/ai/daily-challenge/claim
+  app.post('/daily-challenge/claim', { preHandler: requireAuth }, async (req: any, reply) => {
+    const dateKey = todayKey()
+    const userId: number = req.user.id
+    const claimKey = 'ai:challenge-claimed:' + dateKey + ':' + userId
+    const idempotencyKey = 'challenge-' + dateKey + '-' + userId
+
+    const alreadyClaimed = await redisCache.get(claimKey)
+    if (alreadyClaimed) {
+      return reply.status(400).send({ success: false, error: 'Already claimed today' })
+    }
+
+    const existing = await prisma.pointsTransaction.findUnique({ where: { idempotencyKey } })
+    if (existing) {
+      await redisCache.set(claimKey, '1', 'EX', 86400)
+      return reply.status(400).send({ success: false, error: 'Already claimed today' })
+    }
+
+    const POINTS = 5
+    await prisma.$transaction([
+      prisma.user.update({ where: { id: userId }, data: { points: { increment: POINTS } } }),
+      prisma.pointsTransaction.create({
+        data: {
+          userId,
+          amount: POINTS,
+          type: 'BONUS',
+          description: 'Daily challenge ' + dateKey,
+          idempotencyKey,
+        },
+      }),
+    ])
+
+    await redisCache.set(claimKey, '1', 'EX', 86400)
+    const user = await prisma.user.findUnique({ where: { id: userId }, select: { points: true } })
+
+    return reply.send({ success: true, pointsAdded: POINTS, totalPoints: user?.points ?? 0 })
+  })
+}

--- a/server/src/routes/radio.ts
+++ b/server/src/routes/radio.ts
@@ -1,0 +1,118 @@
+import { FastifyInstance } from 'fastify'
+import { prisma } from '../lib/prisma'
+
+export default async function radioRoutes(app: FastifyInstance) {
+  async function requireAuth(req: any, reply: any) {
+    try { await req.jwtVerify() } catch {
+      return reply.status(401).send({ success: false, error: 'Unauthorized' })
+    }
+  }
+
+  async function requireAdmin(req: any, reply: any) {
+    try { await req.jwtVerify() } catch {
+      return reply.status(401).send({ success: false, error: 'Unauthorized' })
+    }
+    if (!['ADMIN', 'OWNER'].includes(req.user.role)) {
+      return reply.status(403).send({ success: false, error: 'Forbidden' })
+    }
+  }
+
+  // GET /api/radio/playlist
+  app.get('/playlist', async (_req, reply) => {
+    const tracks = await prisma.radioTrack.findMany({
+      where: { isActive: true },
+      orderBy: { position: 'asc' },
+    })
+    return reply.send({ success: true, tracks })
+  })
+
+  // GET /api/radio/now - synchronized radio by server time
+  app.get('/now', async (_req, reply) => {
+    const tracks = await prisma.radioTrack.findMany({
+      where: { isActive: true },
+      orderBy: { position: 'asc' },
+    })
+
+    if (tracks.length === 0) {
+      return reply.send({ success: true, currentTrack: null, position: 0, serverTime: Date.now() })
+    }
+
+    const totalDuration = tracks.reduce((sum, t) => sum + t.duration, 0)
+    if (totalDuration === 0) {
+      return reply.send({ success: true, currentTrack: tracks[0], position: 0, serverTime: Date.now() })
+    }
+
+    const nowSec = Math.floor(Date.now() / 1000)
+    const dayStart = Math.floor(nowSec / 86400) * 86400
+    const elapsed = (nowSec - dayStart) % totalDuration
+
+    let accumulated = 0
+    let currentTrack = tracks[0]
+    let positionInTrack = 0
+
+    for (const track of tracks) {
+      if (elapsed < accumulated + track.duration) {
+        currentTrack = track
+        positionInTrack = elapsed - accumulated
+        break
+      }
+      accumulated += track.duration
+    }
+
+    return reply.send({
+      success: true,
+      currentTrack,
+      position: positionInTrack,
+      serverTime: Date.now(),
+    })
+  })
+
+  // POST /api/radio/add-track
+  app.post('/add-track', { preHandler: requireAdmin }, async (req: any, reply) => {
+    const body = req.body as {
+      fileId?: string
+      title?: string
+      artist?: string
+      duration?: number
+      genre?: string
+      url?: string
+    }
+
+    if (!body.fileId || !body.title || !body.url) {
+      return reply.status(400).send({ success: false, error: 'fileId, title and url are required' })
+    }
+
+    const agg = await prisma.radioTrack.aggregate({ _max: { position: true } })
+    const position = (agg._max.position ?? -1) + 1
+
+    const track = await prisma.radioTrack.create({
+      data: {
+        fileId: body.fileId,
+        title: body.title,
+        artist: body.artist || 'PerkUp Radio',
+        duration: body.duration || 180,
+        genre: body.genre || 'lofi',
+        url: body.url,
+        position,
+        isActive: true,
+      },
+    })
+
+    return reply.status(201).send({ success: true, track })
+  })
+
+  // POST /api/radio/user-genre
+  app.post('/user-genre', { preHandler: requireAuth }, async (req: any, reply) => {
+    const body = req.body as { genre?: string }
+    if (!body.genre || typeof body.genre !== 'string') {
+      return reply.status(400).send({ success: false, error: 'genre required' })
+    }
+
+    await prisma.user.update({
+      where: { id: req.user.id },
+      data: { radioGenre: body.genre },
+    })
+
+    return reply.send({ success: true, genre: body.genre })
+  })
+}


### PR DESCRIPTION
- server/src/routes/ai.ts: weather+Claude recommendation, card-of-day, coffee-fact (12h Redis cache), mood-based menu picker, daily challenge with 5pt reward and idempotency guard
- server/src/routes/radio.ts: playlist, synced /now endpoint, add-track (ADMIN/OWNER), user-genre preference
- server/src/index.ts: register /api/ai and /api/radio route groups
- server/prisma/schema.prisma: add radioGenre String? to User model
- client/src/pages/AiPage.tsx: weather banner, card-of-day, coffee fact, mood picker with preset moods, daily challenge with claim button
- client/src/components/RadioPlayer.tsx: floating synced radio player
- client/src/App.tsx: add /ai route + RadioPlayer overlay
- client/src/components/BottomNav.tsx: replace Fun tab with AI tab
- client/src/lib/api.ts: add aiApi and radioApi helpers

https://claude.ai/code/session_01Ne3LdXdfjtmKv2PxRc41bB