### PR TITLE
Rename game finish API, expand game types, and normalize game status in UI

### DIFF
--- a/client/src/games/MemoryGame.tsx
+++ b/client/src/games/MemoryGame.tsx
@@ -52,7 +52,7 @@ export default function MemoryGame({ onFinish }: Props) {
     clearInterval(timerRef.current)
     setLoading(true)
     try {
-      const res = await gameApi.finishGame('MEMORY', secs)
+      const res = await gameApi.finish('MEMORY', secs)
       const earned = res.data?.pointsWon || res.data?.earnedPoints || 0
       setPts(earned); onFinish(earned)
     } catch { onFinish(0) }

--- a/client/src/games/QuizGame.tsx
+++ b/client/src/games/QuizGame.tsx
@@ -126,7 +126,7 @@ export default function QuizGame({ onFinish }: Props) {
     setIsCorrect(correct)
     setSaving(true)
     try {
-      const res = await gameApi.finishGame('QUIZ', correct ? 1 : 0)
+      const res = await gameApi.finish('QUIZ', correct ? 1 : 0)
       setPts(res.data?.pointsWon || res.data?.earnedPoints || 0)
     } catch {}
     setSaving(false)

--- a/client/src/games/TicTacToe.tsx
+++ b/client/src/games/TicTacToe.tsx
@@ -61,7 +61,7 @@ export default function TicTacToe({ onFinish }: Props) {
     setLoading(true)
     const score = r === 'win' ? 1 : r === 'draw' ? 0.5 : 0
     try {
-      const res = await gameApi.finishGame('TIC_TAC_TOE', score)
+      const res = await gameApi.finish('TIC_TAC_TOE', score)
       const earned = res.data?.pointsWon || res.data?.earnedPoints || 0
       setPts(earned)
     } catch { setPts(0) }

--- a/client/src/games/WordPuzzle.tsx
+++ b/client/src/games/WordPuzzle.tsx
@@ -80,7 +80,7 @@ export default function WordPuzzle({ onFinish }: Props) {
   const finish = useCallback(async (foundWords: string[]) => {
     setLoading(true)
     try {
-      const res = await gameApi.finishGame('WORD_PUZZLE', foundWords.length)
+      const res = await gameApi.finish('WORD_PUZZLE', foundWords.length)
       const earned = res.data?.pointsWon || res.data?.earnedPoints || 0
       setPts(earned); onFinish(earned)
     } catch { onFinish(0) }

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -87,9 +87,24 @@ export const aiApi = {
   claimChallenge: () => api.post('/api/ai/daily-challenge/claim'),
 }
 
+type GameFinishType =
+  | 'TIC_TAC_TOE'
+  | 'MEMORY'
+  | 'QUIZ'
+  | 'WORD_PUZZLE'
+  | 'PERKIE_CATCH'
+  | 'BARISTA_RUSH'
+  | 'MEMORY_COFFEE'
+  | 'PERKIE_JUMP'
+
 export const gameApi = {
   getStatus: () => api.get('/api/game/status'),
-  finishGame: (type: string, score: number) => api.post('/api/game/finish', { type, score }),
+  finish: (typeOrData: GameFinishType | { type: GameFinishType; score: number }, score?: number) => {
+    if (typeof typeOrData === 'string') {
+      return api.post('/api/game/finish', { type: typeOrData, score: score ?? 0 })
+    }
+    return api.post('/api/game/finish', typeOrData)
+  },
   submitScore: (score: number) => api.post('/api/game/coffee-jump/score', { score }),
   getCoffeeJumpLeaderboard: () => api.get('/api/game/coffee-jump/leaderboard'),
   getMyStats: () => api.get('/api/game/coffee-jump/my-stats'),

--- a/client/src/pages/FunPage.tsx
+++ b/client/src/pages/FunPage.tsx
@@ -16,6 +16,20 @@ interface GameStatus {
   canPlay: Record<string, boolean>
 }
 
+function normalizeGameStatus(data: any): GameStatus {
+  const dailyCurrent = data?.daily?.current ?? data?.pointsEarnedToday ?? 0
+  const dailyMax = data?.daily?.max ?? data?.pointsCapToday ?? 60
+  return {
+    daily: {
+      current: Number(dailyCurrent) || 0,
+      max: Number(dailyMax) || 60,
+    },
+    pending: Number(data?.pending) || 0,
+    bonus: Number(data?.bonus) || 0,
+    canPlay: data?.canPlay && typeof data.canPlay === 'object' ? data.canPlay : {},
+  }
+}
+
 const GAMES = [
   { id: 'runner'    as GameId, emoji: '🏃', name: 'PerkUp Runner',   desc: 'Стрибай, збирай зерна',   pts: 'до 10 балів', badge: 'Соло',        badgeColor: 'bg-sky-100 text-sky-700' },
   { id: 'tictactoe' as GameId, emoji: '❌', name: 'Хрестики-нулики', desc: 'Vs AI · Cooldown 4 год',  pts: 'Перемога 5б', badge: '1v1',          badgeColor: 'bg-green-100 text-green-700' },
@@ -38,7 +52,7 @@ export default function FunPage() {
   const loadStatus = useCallback(() => {
     setLoadingStatus(true)
     gameApi.getStatus()
-      .then((r: any) => setStatus(r.data))
+      .then((r: any) => setStatus(normalizeGameStatus(r.data)))
       .catch(() => {})
       .finally(() => setLoadingStatus(false))
   }, [])
@@ -54,8 +68,8 @@ export default function FunPage() {
     setTimeout(() => setGame('hub'), 2500)
   }, [loadStatus])
 
-  const dailyUsed = status?.daily.current ?? 0
-  const dailyMax  = status?.daily.max ?? 60
+  const dailyUsed = status?.daily?.current ?? 0
+  const dailyMax  = status?.daily?.max ?? 60
   const progress  = Math.min(100, Math.round((dailyUsed / dailyMax) * 100))
 
   if (game !== 'hub') {
@@ -104,7 +118,7 @@ export default function FunPage() {
 
       <div className="px-4 mt-5 space-y-3">
         {GAMES.map(g => {
-          const canPlay = !loadingStatus && status?.canPlay[g.id.toUpperCase()] !== false
+          const canPlay = !loadingStatus && status?.canPlay?.[g.id.toUpperCase()] !== false
           return (
             <button key={g.id} onClick={() => setGame(g.id)}
               className="w-full text-left bg-white rounded-2xl border border-stone-100 shadow-sm hover:shadow-md active:scale-[0.98] transition-all overflow-hidden">

--- a/server/src/routes/game.ts
+++ b/server/src/routes/game.ts
@@ -17,7 +17,7 @@ const DAILY_GENERIC_GAME_LIMIT = 30
 const GAME_POINT_CAP_PER_DAY = 60
 
 const gameFinishSchema = z.object({
-  type: z.enum(['TIC_TAC_TOE', 'PERKIE_CATCH', 'BARISTA_RUSH', 'MEMORY_COFFEE', 'PERKIE_JUMP']),
+  type: z.enum(['TIC_TAC_TOE', 'MEMORY', 'QUIZ', 'WORD_PUZZLE', 'PERKIE_CATCH', 'BARISTA_RUSH', 'MEMORY_COFFEE', 'PERKIE_JUMP']),
   score: z.number().int().min(0).max(100000),
 })
 


### PR DESCRIPTION
### Motivation
- Simplify and standardize the client API for reporting game results by replacing `finishGame` with a more flexible `finish` helper and ensure server accepts the broader set of game types. 
- Normalize server status payload shapes in the Fun page so the UI works with both old and new response fields. 

### Description
- Replaced calls to `gameApi.finishGame(...)` with the new `gameApi.finish(...)` in `MemoryGame`, `QuizGame`, `TicTacToe`, and `WordPuzzle`. 
- Implemented a new overloaded `gameApi.finish` in `client/src/lib/api.ts` that accepts either `(type, score)` or an object `{ type, score }`, and introduced `GameFinishType` enum-like type. 
- Extended the server-side finish request schema in `server/src/routes/game.ts` to include `MEMORY`, `QUIZ`, and `WORD_PUZZLE` game types (and kept other existing types). 
- Added `normalizeGameStatus` in `FunPage` to map different backend field names (`pointsEarnedToday` / `pointsCapToday`) into the UI `GameStatus` shape and switched `loadStatus` to use it. 
- Made `canPlay` lookup safer with optional chaining when checking `status.canPlay[g.id.toUpperCase()]` in `FunPage`. 

### Testing
- Ran TypeScript type-check (`tsc --noEmit`) to ensure typings and API changes compile successfully. 
- Performed a local smoke build (`yarn build`) to verify client bundle compilation. 
- Ran the test suite (`yarn test`) and all automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb7f922124832892f099784cd86440)