### PR TITLE
Games: add error boundary/debug logging, normalize game API/status and server-side referral/poster/menu enhancements

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -23,6 +23,7 @@ import CommunityEventDetailsPage from './pages/community/CommunityEventDetailsPa
 import LoadingScreen from './components/LoadingScreen'
 import BottomNav from './components/BottomNav'
 import Header from './components/Header'
+import { GamesRouteDebug } from './components/GamesRouteBoundary'
 
 export default function App() {
   const { login, isAuthenticated, isLoading, user } = useAuthStore()
@@ -47,7 +48,14 @@ export default function App() {
         <Routes>
           <Route path="/" element={<Navigate to="/menu" replace />} />
           <Route path="/menu" element={<MenuPage />} />
-          <Route path="/fun" element={<FunPage />} />
+          <Route
+            path="/fun"
+            element={(
+              <GamesRouteDebug user={user} status={{ isAuthenticated, isLoading }}>
+                <FunPage />
+              </GamesRouteDebug>
+            )}
+          />
           <Route path="/leaderboard" element={<LeaderboardPage />} />
           <Route path="/barista" element={<BaristaPage />} />
           <Route path="/radio" element={<Navigate to="/fun" replace />} />

--- a/client/src/components/GamesRouteBoundary.tsx
+++ b/client/src/components/GamesRouteBoundary.tsx
@@ -1,0 +1,48 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+import { useLocation } from 'react-router-dom'
+
+type GamesRouteBoundaryProps = {
+  children: ReactNode
+}
+
+type GamesRouteBoundaryState = {
+  hasError: boolean
+}
+
+class GamesRouteBoundaryInner extends Component<GamesRouteBoundaryProps, GamesRouteBoundaryState> {
+  state: GamesRouteBoundaryState = { hasError: false }
+
+  static getDerivedStateFromError(): GamesRouteBoundaryState {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('[GamesRouteBoundary] render error', error, errorInfo)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="m-4 rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          Не вдалося відкрити сторінку ігор. Спробуй оновити сторінку.
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}
+
+type GamesRouteDebugProps = {
+  children: ReactNode
+  user: unknown
+  status: unknown
+}
+
+export function GamesRouteDebug({ children, user, status }: GamesRouteDebugProps) {
+  const location = useLocation()
+  console.log('[GamesRoute] render start')
+  console.log('[GamesRoute] user/status/location', { user, status, location: location.pathname + location.search + location.hash })
+
+  return <GamesRouteBoundaryInner>{children}</GamesRouteBoundaryInner>
+}

--- a/client/src/games/MemoryGame.tsx
+++ b/client/src/games/MemoryGame.tsx
@@ -52,7 +52,7 @@ export default function MemoryGame({ onFinish }: Props) {
     clearInterval(timerRef.current)
     setLoading(true)
     try {
-      const res = await gameApi.finishGame('MEMORY', secs)
+      const res = await gameApi.finish('MEMORY', secs)
       const earned = res.data?.pointsWon || res.data?.earnedPoints || 0
       setPts(earned); onFinish(earned)
     } catch { onFinish(0) }

--- a/client/src/games/QuizGame.tsx
+++ b/client/src/games/QuizGame.tsx
@@ -126,7 +126,7 @@ export default function QuizGame({ onFinish }: Props) {
     setIsCorrect(correct)
     setSaving(true)
     try {
-      const res = await gameApi.finishGame('QUIZ', correct ? 1 : 0)
+      const res = await gameApi.finish('QUIZ', correct ? 1 : 0)
       setPts(res.data?.pointsWon || res.data?.earnedPoints || 0)
     } catch {}
     setSaving(false)

--- a/client/src/games/TicTacToe.tsx
+++ b/client/src/games/TicTacToe.tsx
@@ -61,7 +61,7 @@ export default function TicTacToe({ onFinish }: Props) {
     setLoading(true)
     const score = r === 'win' ? 1 : r === 'draw' ? 0.5 : 0
     try {
-      const res = await gameApi.finishGame('TIC_TAC_TOE', score)
+      const res = await gameApi.finish('TIC_TAC_TOE', score)
       const earned = res.data?.pointsWon || res.data?.earnedPoints || 0
       setPts(earned)
     } catch { setPts(0) }

--- a/client/src/games/WordPuzzle.tsx
+++ b/client/src/games/WordPuzzle.tsx
@@ -80,7 +80,7 @@ export default function WordPuzzle({ onFinish }: Props) {
   const finish = useCallback(async (foundWords: string[]) => {
     setLoading(true)
     try {
-      const res = await gameApi.finishGame('WORD_PUZZLE', foundWords.length)
+      const res = await gameApi.finish('WORD_PUZZLE', foundWords.length)
       const earned = res.data?.pointsWon || res.data?.earnedPoints || 0
       setPts(earned); onFinish(earned)
     } catch { onFinish(0) }

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -87,9 +87,24 @@ export const aiApi = {
   claimChallenge: () => api.post('/api/ai/daily-challenge/claim'),
 }
 
+type GameFinishType =
+  | 'TIC_TAC_TOE'
+  | 'MEMORY'
+  | 'QUIZ'
+  | 'WORD_PUZZLE'
+  | 'PERKIE_CATCH'
+  | 'BARISTA_RUSH'
+  | 'MEMORY_COFFEE'
+  | 'PERKIE_JUMP'
+
 export const gameApi = {
   getStatus: () => api.get('/api/game/status'),
-  finishGame: (type: string, score: number) => api.post('/api/game/finish', { type, score }),
+  finish: (typeOrData: GameFinishType | { type: GameFinishType; score: number }, score?: number) => {
+    if (typeof typeOrData === 'string') {
+      return api.post('/api/game/finish', { type: typeOrData, score: score ?? 0 })
+    }
+    return api.post('/api/game/finish', typeOrData)
+  },
   submitScore: (score: number) => api.post('/api/game/coffee-jump/score', { score }),
   getCoffeeJumpLeaderboard: () => api.get('/api/game/coffee-jump/leaderboard'),
   getMyStats: () => api.get('/api/game/coffee-jump/my-stats'),

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -17,10 +17,10 @@ const queryClient = new QueryClient({
 
 const tg = window.Telegram?.WebApp
 if (tg) {
-  tg.ready()
-  tg.expand()
-  tg.setHeaderColor('#3d1c02')
-  tg.setBackgroundColor('#fdf6ed')
+  if (typeof tg.ready === 'function') tg.ready()
+  if (typeof tg.expand === 'function') tg.expand()
+  if (typeof tg.setHeaderColor === 'function') tg.setHeaderColor('#3d1c02')
+  if (typeof tg.setBackgroundColor === 'function') tg.setBackgroundColor('#fdf6ed')
 }
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/client/src/pages/FunPage.tsx
+++ b/client/src/pages/FunPage.tsx
@@ -16,6 +16,20 @@ interface GameStatus {
   canPlay: Record<string, boolean>
 }
 
+function normalizeGameStatus(data: any): GameStatus {
+  const dailyCurrent = data?.daily?.current ?? data?.pointsEarnedToday ?? 0
+  const dailyMax = data?.daily?.max ?? data?.pointsCapToday ?? 60
+  return {
+    daily: {
+      current: Number(dailyCurrent) || 0,
+      max: Number(dailyMax) || 60,
+    },
+    pending: Number(data?.pending) || 0,
+    bonus: Number(data?.bonus) || 0,
+    canPlay: data?.canPlay && typeof data.canPlay === 'object' ? data.canPlay : {},
+  }
+}
+
 const GAMES = [
   { id: 'runner'    as GameId, emoji: '🏃', name: 'PerkUp Runner',   desc: 'Стрибай, збирай зерна',   pts: 'до 10 балів', badge: 'Соло',        badgeColor: 'bg-sky-100 text-sky-700' },
   { id: 'tictactoe' as GameId, emoji: '❌', name: 'Хрестики-нулики', desc: 'Vs AI · Cooldown 4 год',  pts: 'Перемога 5б', badge: '1v1',          badgeColor: 'bg-green-100 text-green-700' },
@@ -38,7 +52,7 @@ export default function FunPage() {
   const loadStatus = useCallback(() => {
     setLoadingStatus(true)
     gameApi.getStatus()
-      .then((r: any) => setStatus(r.data))
+      .then((r: any) => setStatus(normalizeGameStatus(r.data)))
       .catch(() => {})
       .finally(() => setLoadingStatus(false))
   }, [])
@@ -54,9 +68,10 @@ export default function FunPage() {
     setTimeout(() => setGame('hub'), 2500)
   }, [loadStatus])
 
-  const dailyUsed = status?.daily.current ?? 0
-  const dailyMax  = status?.daily.max ?? 60
+  const dailyUsed = status?.daily?.current ?? 0
+  const dailyMax  = status?.daily?.max ?? 60
   const progress  = Math.min(100, Math.round((dailyUsed / dailyMax) * 100))
+  const hasValidStatus = !!status && Number.isFinite(dailyUsed) && Number.isFinite(dailyMax) && dailyMax > 0
 
   if (game !== 'hub') {
     const info = GAMES.find(g => g.id === game)!
@@ -102,9 +117,15 @@ export default function FunPage() {
         <span>Бали нараховуються одразу. Ліміт 60 балів на день.</span>
       </div>
 
+      {(loadingStatus || !hasValidStatus) && (
+        <div className="mx-4 mt-4 bg-white border border-stone-200 rounded-2xl px-4 py-3 text-sm text-stone-600">
+          {loadingStatus ? 'Завантажуємо ігровий статус…' : 'Тимчасово не вдалось отримати статус ігор. Спробуй ще раз.'}
+        </div>
+      )}
+
       <div className="px-4 mt-5 space-y-3">
         {GAMES.map(g => {
-          const canPlay = !loadingStatus && status?.canPlay[g.id.toUpperCase()] !== false
+          const canPlay = hasValidStatus && !loadingStatus && status?.canPlay?.[g.id.toUpperCase()] !== false
           return (
             <button key={g.id} onClick={() => setGame(g.id)}
               className="w-full text-left bg-white rounded-2xl border border-stone-100 shadow-sm hover:shadow-md active:scale-[0.98] transition-all overflow-hidden">

--- a/server/package.json
+++ b/server/package.json
@@ -6,6 +6,7 @@
     "dev": "tsx watch src/index.ts",
     "build": "npx prisma generate && tsc",
     "start": "node dist/index.js",
+    "qa:poster-webhook": "tsx scripts/qa-poster-webhook.ts",
     "db:generate": "prisma generate",
     "db:push": "prisma db push",
     "db:migrate": "prisma migrate deploy",

--- a/server/scripts/qa-poster-webhook.ts
+++ b/server/scripts/qa-poster-webhook.ts
@@ -1,0 +1,73 @@
+type QaCase = {
+  name: string
+  payload: Record<string, unknown>
+  expectedStatus: number
+}
+
+const baseUrl = process.env.QA_BASE_URL || 'http://localhost:3000'
+const endpoint = `${baseUrl.replace(/\/$/, '')}/webhooks/poster`
+
+const cases: QaCase[] = [
+  {
+    name: 'empty payload returns ack',
+    payload: {},
+    expectedStatus: 200,
+  },
+  {
+    name: 'unknown account is safely ignored',
+    payload: {
+      object: 'transaction',
+      action: 'closed',
+      object_id: 123456,
+      account: 'non-existing-poster-account',
+    },
+    expectedStatus: 200,
+  },
+  {
+    name: 'non-transaction event is safely ignored',
+    payload: {
+      object: 'client',
+      action: 'changed',
+      object_id: 777,
+      account: 'non-existing-poster-account',
+    },
+    expectedStatus: 200,
+  },
+]
+
+async function run() {
+  let failed = 0
+
+  for (const testCase of cases) {
+    try {
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(testCase.payload),
+      })
+      const text = await response.text()
+
+      if (response.status !== testCase.expectedStatus) {
+        failed += 1
+        console.error(`❌ ${testCase.name}`)
+        console.error(`   expected status: ${testCase.expectedStatus}, got: ${response.status}`)
+        console.error(`   body: ${text}`)
+      } else {
+        console.log(`✅ ${testCase.name}`)
+      }
+    } catch (error: any) {
+      failed += 1
+      console.error(`❌ ${testCase.name}`)
+      console.error(`   request failed: ${error?.message || String(error)}`)
+    }
+  }
+
+  if (failed > 0) {
+    console.error(`\nPoster webhook QA failed: ${failed} case(s)`)
+    process.exit(1)
+  }
+
+  console.log('\nPoster webhook QA passed')
+}
+
+run()

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -466,6 +466,11 @@ export default async function adminRoutes(app: FastifyInstance) {
       volume: z.string().max(50).optional(),
       calories: z.coerce.number().int().min(0).max(5000).optional(),
       isAvailable: z.boolean().optional(),
+      isHiddenInApp: z.boolean().optional(),
+      isNew: z.boolean().optional(),
+      isTop: z.boolean().optional(),
+      isSeasonal: z.boolean().optional(),
+      isRecommended: z.boolean().optional(),
     }).safeParse(req.body)
     if (!body.success) return reply.status(400).send({ success: false, error: 'Invalid data' })
 
@@ -504,6 +509,11 @@ export default async function adminRoutes(app: FastifyInstance) {
           volume: body.data.volume?.trim() || null,
           calories: body.data.calories,
           isAvailable: body.data.isAvailable ?? true,
+          isHiddenInApp: body.data.isHiddenInApp ?? false,
+          isNew: body.data.isNew ?? false,
+          isTop: body.data.isTop ?? false,
+          isSeasonal: body.data.isSeasonal ?? false,
+          isRecommended: body.data.isRecommended ?? false,
           allergens: [],
           tags: [],
         },
@@ -545,6 +555,11 @@ export default async function adminRoutes(app: FastifyInstance) {
       imageUrl: z.string().url().max(1000).optional().nullable(),
       volume: z.string().max(50).optional().nullable(),
       calories: z.coerce.number().int().min(0).max(5000).optional().nullable(),
+      isHiddenInApp: z.boolean().optional(),
+      isNew: z.boolean().optional(),
+      isTop: z.boolean().optional(),
+      isSeasonal: z.boolean().optional(),
+      isRecommended: z.boolean().optional(),
     }).safeParse(req.body)
     if (!body.success) return reply.status(400).send({ success: false, error: 'Invalid data' })
 
@@ -558,6 +573,11 @@ export default async function adminRoutes(app: FastifyInstance) {
     const data: any = {}
 
     if (body.data.isAvailable !== undefined) data.isAvailable = body.data.isAvailable
+    if (body.data.isHiddenInApp !== undefined) data.isHiddenInApp = body.data.isHiddenInApp
+    if (body.data.isNew !== undefined) data.isNew = body.data.isNew
+    if (body.data.isTop !== undefined) data.isTop = body.data.isTop
+    if (body.data.isSeasonal !== undefined) data.isSeasonal = body.data.isSeasonal
+    if (body.data.isRecommended !== undefined) data.isRecommended = body.data.isRecommended
 
     if (profile.menuManagement === 'LOCAL') {
       if (body.data.price !== undefined) data.price = body.data.price
@@ -567,8 +587,20 @@ export default async function adminRoutes(app: FastifyInstance) {
       if (body.data.imageUrl !== undefined) data.imageUrl = body.data.imageUrl?.trim() || null
       if (body.data.volume !== undefined) data.volume = body.data.volume?.trim() || null
       if (body.data.calories !== undefined) data.calories = body.data.calories
-    } else if (Object.keys(body.data).some((key) => key !== 'isAvailable')) {
-      return reply.status(400).send({ success: false, error: 'Poster menu supports availability only. Edit products in Poster for full changes.' })
+    } else {
+      if (body.data.description !== undefined) data.description = body.data.description?.trim() || null
+      if (body.data.ingredients !== undefined) data.ingredients = body.data.ingredients?.trim() || null
+      if (body.data.imageUrl !== undefined) data.imageUrl = body.data.imageUrl?.trim() || null
+      if (body.data.volume !== undefined) data.volume = body.data.volume?.trim() || null
+      if (body.data.calories !== undefined) data.calories = body.data.calories
+
+      const forbiddenPosterFields = ['price', 'name', 'category']
+      if (forbiddenPosterFields.some((key) => (body.data as any)[key] !== undefined)) {
+        return reply.status(400).send({
+          success: false,
+          error: 'Poster menu supports editing only marketing fields (description, image, badges, visibility, availability).',
+        })
+      }
     }
 
     if (profile.menuManagement === 'LOCAL' && body.data.category && body.data.category !== product.category) {

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -9,7 +9,70 @@ const loginSchema = z.object({
   initData: z.string().min(1),
 })
 
+const REFERRAL_BONUS_FOR_FRIEND = 20
+const REFERRAL_BONUS_FOR_REFERRER = 20
+
 export default async function authRoutes(app: FastifyInstance) {
+  async function applyReferralBonus(userId: number, referrerId: number) {
+    if (userId === referrerId) {
+      return { success: false as const, reason: 'self_referral' }
+    }
+
+    const [user, referrer] = await Promise.all([
+      prisma.user.findUnique({ where: { id: userId }, select: { id: true, referredById: true } }),
+      prisma.user.findUnique({ where: { id: referrerId }, select: { id: true } }),
+    ])
+
+    if (!user || !referrer) {
+      return { success: false as const, reason: 'not_found' }
+    }
+
+    if (user.referredById) {
+      return { success: false as const, reason: 'already_set' }
+    }
+
+    const newUserBonus = REFERRAL_BONUS_FOR_FRIEND
+    const referrerBonus = REFERRAL_BONUS_FOR_REFERRER
+
+    await prisma.$transaction(async (tx) => {
+      const updated = await tx.user.updateMany({
+        where: { id: userId, referredById: null },
+        data: { referredById: referrerId, points: { increment: newUserBonus } },
+      })
+
+      if (updated.count === 0) {
+        throw new Error('ALREADY_SET')
+      }
+
+      await tx.user.update({
+        where: { id: referrerId },
+        data: { points: { increment: referrerBonus } },
+      })
+
+      await tx.pointsTransaction.create({
+        data: {
+          userId,
+          amount: newUserBonus,
+          type: 'REFERRAL',
+          description: 'Реферальний бонус (новий юзер)',
+          idempotencyKey: `ref-new-${userId}`,
+        },
+      })
+
+      await tx.pointsTransaction.create({
+        data: {
+          userId: referrerId,
+          amount: referrerBonus,
+          type: 'REFERRAL',
+          description: 'Реферальний бонус (запросив друга)',
+          idempotencyKey: `ref-referrer-${userId}`,
+        },
+      })
+    })
+
+    return { success: true as const }
+  }
+
   async function claimPendingLoyaltyEvents(userId: number, phone: string) {
     const pending = await prisma.pendingLoyaltyEvent.findMany({
       where: { phone, status: 'PENDING' },
@@ -212,25 +275,17 @@ export default async function authRoutes(app: FastifyInstance) {
         lastName: tgUser.last_name || null,
         username: tgUser.username || null,
         language: tgUser.language_code || 'uk',
-        referredById: referredById || null,
       },
     })
 
-    // Give referral bonus to new user (5 points)
-    if (referredById && user.createdAt.getTime() > Date.now() - 5000) {
-      await prisma.pointsTransaction.create({
-        data: {
-          userId: user.id,
-          amount: 5,
-          type: 'REFERRAL',
-          description: 'Бонус за реєстрацію за реферальним посиланням',
-          idempotencyKey: `referral-new-${user.id}`,
-        },
-      })
-      await prisma.user.update({
-        where: { id: user.id },
-        data: { points: { increment: 5 } },
-      })
+    if (referredById) {
+      try {
+        await applyReferralBonus(user.id, referredById)
+      } catch (error) {
+        if (!(error instanceof Error && error.message === 'ALREADY_SET')) {
+          throw error
+        }
+      }
     }
 
     // Generate JWT
@@ -314,46 +369,19 @@ export default async function authRoutes(app: FastifyInstance) {
       return reply.send({ success: false, reason: 'self_referral' })
     }
 
-    const user = await prisma.user.findUnique({ where: { telegramId } })
-    const referrer = await prisma.user.findUnique({ where: { telegramId: referrerTelegramId } })
-    if (!user || !referrer || user.referredById) {
-      return reply.send({ success: false, reason: 'already_set' })
+    const user = await prisma.user.findUnique({ where: { telegramId }, select: { id: true } })
+    const referrer = await prisma.user.findUnique({ where: { telegramId: referrerTelegramId }, select: { id: true } })
+    if (!user || !referrer) {
+      return reply.send({ success: false, reason: 'not_found' })
     }
 
-    const newUserBonus = 20
-    const referrerBonus = 20
-
     try {
-      await prisma.$transaction([
-        prisma.user.update({
-          where: { id: user.id },
-          data: { referredById: referrer.id, points: { increment: newUserBonus } },
-        }),
-        prisma.user.update({
-          where: { id: referrer.id },
-          data: { points: { increment: referrerBonus } },
-        }),
-        prisma.pointsTransaction.create({
-          data: {
-            userId: user.id,
-            amount: newUserBonus,
-            type: 'REFERRAL',
-            description: '\u0420\u0435\u0444\u0435\u0440\u0430\u043b\u044c\u043d\u0438\u0439 \u0431\u043e\u043d\u0443\u0441 (\u043d\u043e\u0432\u0438\u0439 \u044e\u0437\u0435\u0440)',
-            idempotencyKey: 'ref-new-' + user.id,
-          },
-        }),
-        prisma.pointsTransaction.create({
-          data: {
-            userId: referrer.id,
-            amount: referrerBonus,
-            type: 'REFERRAL',
-            description: '\u0420\u0435\u0444\u0435\u0440\u0430\u043b\u044c\u043d\u0438\u0439 \u0431\u043e\u043d\u0443\u0441 (\u0437\u0430\u043f\u0440\u043e\u0441\u0438\u0432 \u0434\u0440\u0443\u0433\u0430)',
-            idempotencyKey: 'ref-referrer-' + user.id,
-          },
-        }),
-      ])
-      return reply.send({ success: true })
+      const result = await applyReferralBonus(user.id, referrer.id)
+      return reply.send(result)
     } catch (error) {
+      if (error instanceof Error && error.message === 'ALREADY_SET') {
+        return reply.send({ success: false, reason: 'already_set' })
+      }
       return reply.status(500).send({ success: false, reason: (error as Error).message })
     }
   })

--- a/server/src/routes/game.ts
+++ b/server/src/routes/game.ts
@@ -17,7 +17,7 @@ const DAILY_GENERIC_GAME_LIMIT = 30
 const GAME_POINT_CAP_PER_DAY = 60
 
 const gameFinishSchema = z.object({
-  type: z.enum(['TIC_TAC_TOE', 'PERKIE_CATCH', 'BARISTA_RUSH', 'MEMORY_COFFEE', 'PERKIE_JUMP']),
+  type: z.enum(['TIC_TAC_TOE', 'MEMORY', 'QUIZ', 'WORD_PUZZLE', 'PERKIE_CATCH', 'BARISTA_RUSH', 'MEMORY_COFFEE', 'PERKIE_JUMP']),
   score: z.number().int().min(0).max(100000),
 })
 

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -132,4 +132,86 @@ export default async function healthRoutes(app: FastifyInstance) {
 
     return reply.send({ success: true, timestamp: new Date().toISOString(), results })
   })
+
+  // Poster integration health by location
+  app.get('/poster', async (_req, reply) => {
+    const locations = await prisma.location.findMany({
+      where: { isActive: true, hasPoster: true },
+      select: {
+        id: true,
+        slug: true,
+        name: true,
+        posterSubdomain: true,
+        posterToken: true,
+      },
+      orderBy: { id: 'asc' },
+    })
+
+    const checks = await Promise.all(locations.map(async (location) => {
+      if (!location.posterSubdomain) {
+        return {
+          slug: location.slug,
+          name: location.name,
+          status: 'error',
+          error: 'posterSubdomain_missing',
+        }
+      }
+      if (!location.posterToken) {
+        return {
+          slug: location.slug,
+          name: location.name,
+          status: 'error',
+          error: 'posterToken_missing',
+        }
+      }
+
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), 7000)
+      try {
+        const url = `https://${location.posterSubdomain}.joinposter.com/api/menu.getProducts?token=${location.posterToken}`
+        const res = await fetch(url, { signal: controller.signal })
+        if (!res.ok) {
+          return {
+            slug: location.slug,
+            name: location.name,
+            status: 'error',
+            error: `http_${res.status}`,
+          }
+        }
+        const data: any = await res.json()
+        const products = Array.isArray(data?.response) ? data.response.length : null
+        if (!Array.isArray(data?.response)) {
+          return {
+            slug: location.slug,
+            name: location.name,
+            status: 'error',
+            error: 'bad_response',
+          }
+        }
+        return {
+          slug: location.slug,
+          name: location.name,
+          status: 'ok',
+          products,
+        }
+      } catch (error: any) {
+        return {
+          slug: location.slug,
+          name: location.name,
+          status: 'error',
+          error: error?.name === 'AbortError' ? 'timeout' : (error?.message || 'fetch_failed'),
+        }
+      } finally {
+        clearTimeout(timer)
+      }
+    }))
+
+    const hasError = checks.some((c) => c.status !== 'ok')
+    return reply.status(hasError ? 503 : 200).send({
+      status: hasError ? 'degraded' : 'ok',
+      timestamp: new Date().toISOString(),
+      totalPosterLocations: locations.length,
+      checks,
+    })
+  })
 }

--- a/server/src/routes/loyalty.ts
+++ b/server/src/routes/loyalty.ts
@@ -4,6 +4,8 @@ import crypto from 'crypto'
 import { getLevel, getLevelMultiplier, getNextLevel } from '../lib/loyalty'
 
 const BOT = process.env.BOT_TOKEN || ''
+const REFERRAL_BONUS_FOR_FRIEND = 20
+const REFERRAL_BONUS_FOR_REFERRER = 20
 
 async function tgSend(chatId: string, text: string) {
   if (!BOT) return
@@ -86,6 +88,30 @@ export default async function loyaltyRoutes(app: FastifyInstance) {
     return reply.send({
       success: true, points, level, multiplier, nextLevel,
       spinsAvailable, completedOrders, transactions, vouchers,
+    })
+  })
+
+  app.get('/referral', { preHandler: requireAuth }, async (req: any, reply: any) => {
+    const user = await prisma.user.findUnique({
+      where: { id: req.user.id },
+      select: { id: true },
+    })
+    if (!user) return reply.status(404).send({ success: false, error: 'Not found' })
+
+    const invitedCount = await prisma.user.count({
+      where: { referredById: user.id },
+    })
+
+    const referralCode = `ref_${user.id}`
+    const referralLink = `https://t.me/${process.env.BOT_USERNAME || 'perkupbot'}?start=${referralCode}`
+
+    return reply.send({
+      success: true,
+      referralCode,
+      referralLink,
+      invitedCount,
+      bonusForFriend: REFERRAL_BONUS_FOR_FRIEND,
+      bonusForReferrer: REFERRAL_BONUS_FOR_REFERRER,
     })
   })
 

--- a/server/src/routes/menu.ts
+++ b/server/src/routes/menu.ts
@@ -7,6 +7,14 @@ import { buildMenuQrSvg, buildPrintableMenuHtml, groupProductsByCategory, sortMe
 
 const MENU_CACHE_TTL = 1800; // 30 хвилин
 
+function getPrimaryBadge(product: any): 'NEW' | 'TOP' | 'SEASONAL' | 'RECOMMENDED' | null {
+  if (product.isNew) return 'NEW'
+  if (product.isTop) return 'TOP'
+  if (product.isSeasonal) return 'SEASONAL'
+  if (product.isRecommended) return 'RECOMMENDED'
+  return null
+}
+
 function getBaseUrl(req: any) {
   const forwardedProto = String(req.headers['x-forwarded-proto'] || '').split(',')[0].trim()
   const protocol = forwardedProto || req.protocol || 'https'
@@ -78,6 +86,7 @@ export default async function menuRoutes(app: FastifyInstance) {
     products = products.map((p: any) => ({
       ...p,
       displayImageUrl: p.imageUrl || p.posterImageUrl || null,
+      primaryBadge: getPrimaryBadge(p),
     }))
 
     // Apply filters


### PR DESCRIPTION
### Motivation
- Improve resilience and observability for the /fun games route by adding an error boundary and debug logging.
- Consolidate and type the game finish API surface and normalize varying backend responses for game status in the client.
- Support referral bonus flows more robustly and expose referral info via the loyalty API.
- Add Poster integration health checks and marketing/product badge fields with controlled editing for Poster-managed menus.

### Description
- Added `GamesRouteBoundary` component with an error boundary and debug logging and wrapped the `/fun` route in `App.tsx` to catch and surface game render errors.
- Replaced calls to `gameApi.finishGame` with a new flexible `gameApi.finish` and introduced `GameFinishType` in `client/src/lib/api.ts` to type game finish payloads.
- Updated game components (`MemoryGame`, `QuizGame`, `TicTacToe`, `WordPuzzle`) to use the new `finish` API and preserved existing earned-points parsing logic.
- Improved `FunPage` by adding `normalizeGameStatus` to handle different backend shapes, added UI for loading/invalid status, and updated `canPlay` checks to be defensive.
- Made Telegram WebApp calls in `main.tsx` safe by checking for function presence before invoking `ready`, `expand`, `setHeaderColor`, and `setBackgroundColor`.
- Server-side: refactored referral logic in `auth` routes by extracting `applyReferralBonus` and used it for both login and bot-referral flows; added constants for referral bonuses and safer error handling.
- Added `/referral` endpoint to `loyalty` routes to expose referral link/code, invited count and bonus amounts.
- Admin/menu changes: added marketing/visibility fields (`isHiddenInApp`, `isNew`, `isTop`, `isSeasonal`, `isRecommended`) to product create/patch endpoints and enforced allowed edits for Poster-managed menus, plus `primaryBadge` computation in `menu` route.
- Health checks: added `/poster` endpoint to check Poster integration per location with timeouts and aggregated status.
- Added `server/scripts/qa-poster-webhook.ts` QA script and `qa:poster-webhook` npm script in `server/package.json`.

### Testing
- Type-checked and built the server code with `npm run build` in the `server` package and the build completed successfully.
- Performed a frontend type-check by running the client TypeScript type-check (`tsc`/project typecheck), which succeeded with no new errors.
- Performed basic smoke checks against updated endpoints (`GET /api/game/status`, `GET /api/menu/:locationSlug`, `GET /api/health/poster`) during development; responses were returned as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb7f922124832892f099784cd86440)