### PR TITLE
Games/debug boundary, game API/status normalization, no-show flow + referral, menu/product metadata and health checks

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -23,6 +23,7 @@ import CommunityEventDetailsPage from './pages/community/CommunityEventDetailsPa
 import LoadingScreen from './components/LoadingScreen'
 import BottomNav from './components/BottomNav'
 import Header from './components/Header'
+import { GamesRouteDebug } from './components/GamesRouteBoundary'
 
 export default function App() {
   const { login, isAuthenticated, isLoading, user } = useAuthStore()
@@ -47,7 +48,14 @@ export default function App() {
         <Routes>
           <Route path="/" element={<Navigate to="/menu" replace />} />
           <Route path="/menu" element={<MenuPage />} />
-          <Route path="/fun" element={<FunPage />} />
+          <Route
+            path="/fun"
+            element={(
+              <GamesRouteDebug user={user} status={{ isAuthenticated, isLoading }}>
+                <FunPage />
+              </GamesRouteDebug>
+            )}
+          />
           <Route path="/leaderboard" element={<LeaderboardPage />} />
           <Route path="/barista" element={<BaristaPage />} />
           <Route path="/radio" element={<Navigate to="/fun" replace />} />

--- a/client/src/components/GamesRouteBoundary.tsx
+++ b/client/src/components/GamesRouteBoundary.tsx
@@ -1,0 +1,48 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react'
+import { useLocation } from 'react-router-dom'
+
+type GamesRouteBoundaryProps = {
+  children: ReactNode
+}
+
+type GamesRouteBoundaryState = {
+  hasError: boolean
+}
+
+class GamesRouteBoundaryInner extends Component<GamesRouteBoundaryProps, GamesRouteBoundaryState> {
+  state: GamesRouteBoundaryState = { hasError: false }
+
+  static getDerivedStateFromError(): GamesRouteBoundaryState {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('[GamesRouteBoundary] render error', error, errorInfo)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="m-4 rounded-2xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          Не вдалося відкрити сторінку ігор. Спробуй оновити сторінку.
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}
+
+type GamesRouteDebugProps = {
+  children: ReactNode
+  user: unknown
+  status: unknown
+}
+
+export function GamesRouteDebug({ children, user, status }: GamesRouteDebugProps) {
+  const location = useLocation()
+  console.log('[GamesRoute] render start')
+  console.log('[GamesRoute] user/status/location', { user, status, location: location.pathname + location.search + location.hash })
+
+  return <GamesRouteBoundaryInner>{children}</GamesRouteBoundaryInner>
+}

--- a/client/src/games/MemoryGame.tsx
+++ b/client/src/games/MemoryGame.tsx
@@ -52,7 +52,7 @@ export default function MemoryGame({ onFinish }: Props) {
     clearInterval(timerRef.current)
     setLoading(true)
     try {
-      const res = await gameApi.finishGame('MEMORY', secs)
+      const res = await gameApi.finish('MEMORY', secs)
       const earned = res.data?.pointsWon || res.data?.earnedPoints || 0
       setPts(earned); onFinish(earned)
     } catch { onFinish(0) }

--- a/client/src/games/QuizGame.tsx
+++ b/client/src/games/QuizGame.tsx
@@ -126,7 +126,7 @@ export default function QuizGame({ onFinish }: Props) {
     setIsCorrect(correct)
     setSaving(true)
     try {
-      const res = await gameApi.finishGame('QUIZ', correct ? 1 : 0)
+      const res = await gameApi.finish('QUIZ', correct ? 1 : 0)
       setPts(res.data?.pointsWon || res.data?.earnedPoints || 0)
     } catch {}
     setSaving(false)

--- a/client/src/games/TicTacToe.tsx
+++ b/client/src/games/TicTacToe.tsx
@@ -61,7 +61,7 @@ export default function TicTacToe({ onFinish }: Props) {
     setLoading(true)
     const score = r === 'win' ? 1 : r === 'draw' ? 0.5 : 0
     try {
-      const res = await gameApi.finishGame('TIC_TAC_TOE', score)
+      const res = await gameApi.finish('TIC_TAC_TOE', score)
       const earned = res.data?.pointsWon || res.data?.earnedPoints || 0
       setPts(earned)
     } catch { setPts(0) }

--- a/client/src/games/WordPuzzle.tsx
+++ b/client/src/games/WordPuzzle.tsx
@@ -80,7 +80,7 @@ export default function WordPuzzle({ onFinish }: Props) {
   const finish = useCallback(async (foundWords: string[]) => {
     setLoading(true)
     try {
-      const res = await gameApi.finishGame('WORD_PUZZLE', foundWords.length)
+      const res = await gameApi.finish('WORD_PUZZLE', foundWords.length)
       const earned = res.data?.pointsWon || res.data?.earnedPoints || 0
       setPts(earned); onFinish(earned)
     } catch { onFinish(0) }

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -87,9 +87,24 @@ export const aiApi = {
   claimChallenge: () => api.post('/api/ai/daily-challenge/claim'),
 }
 
+type GameFinishType =
+  | 'TIC_TAC_TOE'
+  | 'MEMORY'
+  | 'QUIZ'
+  | 'WORD_PUZZLE'
+  | 'PERKIE_CATCH'
+  | 'BARISTA_RUSH'
+  | 'MEMORY_COFFEE'
+  | 'PERKIE_JUMP'
+
 export const gameApi = {
   getStatus: () => api.get('/api/game/status'),
-  finishGame: (type: string, score: number) => api.post('/api/game/finish', { type, score }),
+  finish: (typeOrData: GameFinishType | { type: GameFinishType; score: number }, score?: number) => {
+    if (typeof typeOrData === 'string') {
+      return api.post('/api/game/finish', { type: typeOrData, score: score ?? 0 })
+    }
+    return api.post('/api/game/finish', typeOrData)
+  },
   submitScore: (score: number) => api.post('/api/game/coffee-jump/score', { score }),
   getCoffeeJumpLeaderboard: () => api.get('/api/game/coffee-jump/leaderboard'),
   getMyStats: () => api.get('/api/game/coffee-jump/my-stats'),

--- a/client/src/lib/i18n.ts
+++ b/client/src/lib/i18n.ts
@@ -119,6 +119,7 @@ const translations: Record<string, Record<Lang, string>> = {
   'order.status.COMPLETED': { uk: '✅ Завершено', en: '✅ Completed' },
   'order.status.CANCELLED': { uk: '❌ Скасовано', en: '❌ Cancelled' },
   'order.status.UNASSIGNED': { uk: '📋 Без зміни', en: '📋 Unassigned' },
+  'order.repeat': { uk: 'Повторити замовлення ☕', en: 'Repeat order ☕' },
 
   // ─── Profile ───
   'profile.level': { uk: 'рівень', en: 'level' },

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -17,10 +17,10 @@ const queryClient = new QueryClient({
 
 const tg = window.Telegram?.WebApp
 if (tg) {
-  tg.ready()
-  tg.expand()
-  tg.setHeaderColor('#3d1c02')
-  tg.setBackgroundColor('#fdf6ed')
+  if (typeof tg.ready === 'function') tg.ready()
+  if (typeof tg.expand === 'function') tg.expand()
+  if (typeof tg.setHeaderColor === 'function') tg.setHeaderColor('#3d1c02')
+  if (typeof tg.setBackgroundColor === 'function') tg.setBackgroundColor('#fdf6ed')
 }
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/client/src/pages/CheckoutPage.tsx
+++ b/client/src/pages/CheckoutPage.tsx
@@ -49,7 +49,13 @@ export default function CheckoutPage() {
       clearCart()
       navigate(`/orders/${res.data.orderId}`)
     } catch (e: any) {
-      setError(e?.response?.data?.error || t('common.error'))
+      const apiError = e?.response?.data?.error
+      const apiMessage = e?.response?.data?.message
+      if (apiError === 'CASH_PAYMENT_BLOCKED') {
+        setError(apiMessage || 'Передзамовлення з оплатою на касі тимчасово обмежено. Зверніться до бариста або адміністратора.')
+      } else {
+        setError(apiError || t('common.error'))
+      }
     } finally {
       setLoading(false)
     }

--- a/client/src/pages/FunPage.tsx
+++ b/client/src/pages/FunPage.tsx
@@ -16,6 +16,20 @@ interface GameStatus {
   canPlay: Record<string, boolean>
 }
 
+function normalizeGameStatus(data: any): GameStatus {
+  const dailyCurrent = data?.daily?.current ?? data?.pointsEarnedToday ?? 0
+  const dailyMax = data?.daily?.max ?? data?.pointsCapToday ?? 60
+  return {
+    daily: {
+      current: Number(dailyCurrent) || 0,
+      max: Number(dailyMax) || 60,
+    },
+    pending: Number(data?.pending) || 0,
+    bonus: Number(data?.bonus) || 0,
+    canPlay: data?.canPlay && typeof data.canPlay === 'object' ? data.canPlay : {},
+  }
+}
+
 const GAMES = [
   { id: 'runner'    as GameId, emoji: '🏃', name: 'PerkUp Runner',   desc: 'Стрибай, збирай зерна',   pts: 'до 10 балів', badge: 'Соло',        badgeColor: 'bg-sky-100 text-sky-700' },
   { id: 'tictactoe' as GameId, emoji: '❌', name: 'Хрестики-нулики', desc: 'Vs AI · Cooldown 4 год',  pts: 'Перемога 5б', badge: '1v1',          badgeColor: 'bg-green-100 text-green-700' },
@@ -38,7 +52,7 @@ export default function FunPage() {
   const loadStatus = useCallback(() => {
     setLoadingStatus(true)
     gameApi.getStatus()
-      .then((r: any) => setStatus(r.data))
+      .then((r: any) => setStatus(normalizeGameStatus(r.data)))
       .catch(() => {})
       .finally(() => setLoadingStatus(false))
   }, [])
@@ -54,9 +68,10 @@ export default function FunPage() {
     setTimeout(() => setGame('hub'), 2500)
   }, [loadStatus])
 
-  const dailyUsed = status?.daily.current ?? 0
-  const dailyMax  = status?.daily.max ?? 60
+  const dailyUsed = status?.daily?.current ?? 0
+  const dailyMax  = status?.daily?.max ?? 60
   const progress  = Math.min(100, Math.round((dailyUsed / dailyMax) * 100))
+  const hasValidStatus = !!status && Number.isFinite(dailyUsed) && Number.isFinite(dailyMax) && dailyMax > 0
 
   if (game !== 'hub') {
     const info = GAMES.find(g => g.id === game)!
@@ -102,9 +117,15 @@ export default function FunPage() {
         <span>Бали нараховуються одразу. Ліміт 60 балів на день.</span>
       </div>
 
+      {(loadingStatus || !hasValidStatus) && (
+        <div className="mx-4 mt-4 bg-white border border-stone-200 rounded-2xl px-4 py-3 text-sm text-stone-600">
+          {loadingStatus ? 'Завантажуємо ігровий статус…' : 'Тимчасово не вдалось отримати статус ігор. Спробуй ще раз.'}
+        </div>
+      )}
+
       <div className="px-4 mt-5 space-y-3">
         {GAMES.map(g => {
-          const canPlay = !loadingStatus && status?.canPlay[g.id.toUpperCase()] !== false
+          const canPlay = hasValidStatus && !loadingStatus && status?.canPlay?.[g.id.toUpperCase()] !== false
           return (
             <button key={g.id} onClick={() => setGame(g.id)}
               className="w-full text-left bg-white rounded-2xl border border-stone-100 shadow-sm hover:shadow-md active:scale-[0.98] transition-all overflow-hidden">

--- a/client/src/pages/OrderStatusPage.tsx
+++ b/client/src/pages/OrderStatusPage.tsx
@@ -2,6 +2,8 @@ import { useQuery } from '@tanstack/react-query'
 import { useParams, useNavigate } from 'react-router-dom'
 import { ordersApi } from '../lib/api'
 import { useT } from '../lib/i18n'
+import { useCartStore } from '../stores/cart'
+import { useLocationStore } from '../stores/location'
 
 const STATUS_CONFIG: Record<string, { label: string; emoji: string; color: string; description: string }> = {
   PENDING:      { label: 'Очікує',          emoji: '⏳', color: 'text-yellow-600 bg-yellow-50 border-yellow-200',   description: 'Замовлення отримано, очікує підтвердження' },
@@ -18,6 +20,8 @@ export default function OrderStatusPage() {
   const { id } = useParams()
   const navigate = useNavigate()
   const t = useT()
+  const { clearCart, addItem } = useCartStore()
+  const setActiveLocation = useLocationStore(s => s.setActiveLocation)
 
   const query = useQuery({
     queryKey: ['order', id],
@@ -44,6 +48,31 @@ export default function OrderStatusPage() {
 
   const order = query.data
   const cfg = STATUS_CONFIG[order.status] || STATUS_CONFIG.PENDING
+  const canRepeatOrder = order.status === 'COMPLETED' || order.status === 'CANCELLED'
+
+  const handleRepeatOrder = () => {
+    if (!order.items?.length) return
+
+    clearCart()
+
+    if (order.location) {
+      setActiveLocation(order.location)
+    }
+
+    order.items.forEach((item: any) => {
+      addItem({
+        productId: item.productId,
+        bundleId: item.bundleId,
+        name: item.name,
+        price: Number(item.price),
+        quantity: Number(item.quantity) || 1,
+        modifiers: item.modifiers || undefined,
+        locationId: order.location?.id,
+      })
+    })
+
+    navigate('/cart')
+  }
 
   return (
     <div className="p-4 pb-24 space-y-4 max-w-lg mx-auto">
@@ -105,9 +134,9 @@ export default function OrderStatusPage() {
         </div>
       )}
 
-      {order.status === 'COMPLETED' && (
-        <button onClick={() => navigate('/menu')} className="w-full py-3 rounded-2xl bg-coffee-600 text-white font-semibold">
-          Зробити нове замовлення ☕
+      {canRepeatOrder && (
+        <button onClick={handleRepeatOrder} className="w-full py-3 rounded-2xl bg-coffee-600 text-white font-semibold">
+          {t('order.repeat')}
         </button>
       )}
     </div>

--- a/docs/no-show-qa-checklist.md
+++ b/docs/no-show-qa-checklist.md
@@ -1,0 +1,16 @@
+# No-show protection QA checklist
+
+1. User creates preorder for Poster location (Krona/Pryozernyi) via `POST /api/orders`.
+2. Barista/Admin marks order as no-show via `POST /api/orders/:id/no-show`.
+3. Verify `noShowCount` increments by 1.
+4. Repeat `POST /api/orders/:id/no-show` for the same order:
+   - response should return `alreadyMarked: true`;
+   - `noShowCount` must not increment again.
+5. Mark enough different orders as no-show to reach threshold (`3`):
+   - verify `cashPaymentBlocked = true`.
+6. Try creating new preorder with cashier payment in Poster location:
+   - must be blocked with `error = CASH_PAYMENT_BLOCKED`.
+7. Admin/Owner calls `POST /api/admin/users/:id/reset-no-show`:
+   - verify response shows `noShowCount = 0`, `cashPaymentBlocked = false`.
+8. Confirm Poster webhook runtime behavior is unchanged:
+   - `transaction:closed` still completes paid orders and awards points.

--- a/server/package.json
+++ b/server/package.json
@@ -6,6 +6,7 @@
     "dev": "tsx watch src/index.ts",
     "build": "npx prisma generate && tsc",
     "start": "node dist/index.js",
+    "qa:poster-webhook": "tsx scripts/qa-poster-webhook.ts",
     "db:generate": "prisma generate",
     "db:push": "prisma db push",
     "db:migrate": "prisma migrate deploy",

--- a/server/scripts/qa-poster-webhook.ts
+++ b/server/scripts/qa-poster-webhook.ts
@@ -1,0 +1,73 @@
+type QaCase = {
+  name: string
+  payload: Record<string, unknown>
+  expectedStatus: number
+}
+
+const baseUrl = process.env.QA_BASE_URL || 'http://localhost:3000'
+const endpoint = `${baseUrl.replace(/\/$/, '')}/webhooks/poster`
+
+const cases: QaCase[] = [
+  {
+    name: 'empty payload returns ack',
+    payload: {},
+    expectedStatus: 200,
+  },
+  {
+    name: 'unknown account is safely ignored',
+    payload: {
+      object: 'transaction',
+      action: 'closed',
+      object_id: 123456,
+      account: 'non-existing-poster-account',
+    },
+    expectedStatus: 200,
+  },
+  {
+    name: 'non-transaction event is safely ignored',
+    payload: {
+      object: 'client',
+      action: 'changed',
+      object_id: 777,
+      account: 'non-existing-poster-account',
+    },
+    expectedStatus: 200,
+  },
+]
+
+async function run() {
+  let failed = 0
+
+  for (const testCase of cases) {
+    try {
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(testCase.payload),
+      })
+      const text = await response.text()
+
+      if (response.status !== testCase.expectedStatus) {
+        failed += 1
+        console.error(`❌ ${testCase.name}`)
+        console.error(`   expected status: ${testCase.expectedStatus}, got: ${response.status}`)
+        console.error(`   body: ${text}`)
+      } else {
+        console.log(`✅ ${testCase.name}`)
+      }
+    } catch (error: any) {
+      failed += 1
+      console.error(`❌ ${testCase.name}`)
+      console.error(`   request failed: ${error?.message || String(error)}`)
+    }
+  }
+
+  if (failed > 0) {
+    console.error(`\nPoster webhook QA failed: ${failed} case(s)`)
+    process.exit(1)
+  }
+
+  console.log('\nPoster webhook QA passed')
+}
+
+run()

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -155,6 +155,35 @@ export default async function adminRoutes(app: FastifyInstance) {
     return reply.send({ success: true, user })
   })
 
+  app.post('/users/:id/reset-no-show', { preHandler: adminOnly }, async (req: any, reply: any) => {
+    const id = Number(req.params.id)
+    if (!Number.isInteger(id) || id <= 0) {
+      return reply.status(400).send({ success: false, error: 'Invalid user id' })
+    }
+
+    const user = await prisma.user.update({
+      where: { id },
+      data: {
+        noShowCount: 0,
+        cashPaymentBlocked: false,
+      },
+      select: {
+        id: true,
+        noShowCount: true,
+        cashPaymentBlocked: true,
+      },
+    }).catch(() => null)
+
+    if (!user) return reply.status(404).send({ success: false, error: 'User not found' })
+
+    return reply.send({
+      success: true,
+      userId: user.id,
+      noShowCount: user.noShowCount,
+      cashPaymentBlocked: user.cashPaymentBlocked,
+    })
+  })
+
   app.get('/orders', { preHandler: adminOnly }, async (req: any, reply: any) => {
     const query = z.object({
       page: z.coerce.number().int().min(1).default(1),
@@ -466,6 +495,11 @@ export default async function adminRoutes(app: FastifyInstance) {
       volume: z.string().max(50).optional(),
       calories: z.coerce.number().int().min(0).max(5000).optional(),
       isAvailable: z.boolean().optional(),
+      isHiddenInApp: z.boolean().optional(),
+      isNew: z.boolean().optional(),
+      isTop: z.boolean().optional(),
+      isSeasonal: z.boolean().optional(),
+      isRecommended: z.boolean().optional(),
     }).safeParse(req.body)
     if (!body.success) return reply.status(400).send({ success: false, error: 'Invalid data' })
 
@@ -504,6 +538,11 @@ export default async function adminRoutes(app: FastifyInstance) {
           volume: body.data.volume?.trim() || null,
           calories: body.data.calories,
           isAvailable: body.data.isAvailable ?? true,
+          isHiddenInApp: body.data.isHiddenInApp ?? false,
+          isNew: body.data.isNew ?? false,
+          isTop: body.data.isTop ?? false,
+          isSeasonal: body.data.isSeasonal ?? false,
+          isRecommended: body.data.isRecommended ?? false,
           allergens: [],
           tags: [],
         },
@@ -545,6 +584,11 @@ export default async function adminRoutes(app: FastifyInstance) {
       imageUrl: z.string().url().max(1000).optional().nullable(),
       volume: z.string().max(50).optional().nullable(),
       calories: z.coerce.number().int().min(0).max(5000).optional().nullable(),
+      isHiddenInApp: z.boolean().optional(),
+      isNew: z.boolean().optional(),
+      isTop: z.boolean().optional(),
+      isSeasonal: z.boolean().optional(),
+      isRecommended: z.boolean().optional(),
     }).safeParse(req.body)
     if (!body.success) return reply.status(400).send({ success: false, error: 'Invalid data' })
 
@@ -558,6 +602,11 @@ export default async function adminRoutes(app: FastifyInstance) {
     const data: any = {}
 
     if (body.data.isAvailable !== undefined) data.isAvailable = body.data.isAvailable
+    if (body.data.isHiddenInApp !== undefined) data.isHiddenInApp = body.data.isHiddenInApp
+    if (body.data.isNew !== undefined) data.isNew = body.data.isNew
+    if (body.data.isTop !== undefined) data.isTop = body.data.isTop
+    if (body.data.isSeasonal !== undefined) data.isSeasonal = body.data.isSeasonal
+    if (body.data.isRecommended !== undefined) data.isRecommended = body.data.isRecommended
 
     if (profile.menuManagement === 'LOCAL') {
       if (body.data.price !== undefined) data.price = body.data.price
@@ -567,8 +616,20 @@ export default async function adminRoutes(app: FastifyInstance) {
       if (body.data.imageUrl !== undefined) data.imageUrl = body.data.imageUrl?.trim() || null
       if (body.data.volume !== undefined) data.volume = body.data.volume?.trim() || null
       if (body.data.calories !== undefined) data.calories = body.data.calories
-    } else if (Object.keys(body.data).some((key) => key !== 'isAvailable')) {
-      return reply.status(400).send({ success: false, error: 'Poster menu supports availability only. Edit products in Poster for full changes.' })
+    } else {
+      if (body.data.description !== undefined) data.description = body.data.description?.trim() || null
+      if (body.data.ingredients !== undefined) data.ingredients = body.data.ingredients?.trim() || null
+      if (body.data.imageUrl !== undefined) data.imageUrl = body.data.imageUrl?.trim() || null
+      if (body.data.volume !== undefined) data.volume = body.data.volume?.trim() || null
+      if (body.data.calories !== undefined) data.calories = body.data.calories
+
+      const forbiddenPosterFields = ['price', 'name', 'category']
+      if (forbiddenPosterFields.some((key) => (body.data as any)[key] !== undefined)) {
+        return reply.status(400).send({
+          success: false,
+          error: 'Poster menu supports editing only marketing fields (description, image, badges, visibility, availability).',
+        })
+      }
     }
 
     if (profile.menuManagement === 'LOCAL' && body.data.category && body.data.category !== product.category) {

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -9,7 +9,70 @@ const loginSchema = z.object({
   initData: z.string().min(1),
 })
 
+const REFERRAL_BONUS_FOR_FRIEND = 20
+const REFERRAL_BONUS_FOR_REFERRER = 20
+
 export default async function authRoutes(app: FastifyInstance) {
+  async function applyReferralBonus(userId: number, referrerId: number) {
+    if (userId === referrerId) {
+      return { success: false as const, reason: 'self_referral' }
+    }
+
+    const [user, referrer] = await Promise.all([
+      prisma.user.findUnique({ where: { id: userId }, select: { id: true, referredById: true } }),
+      prisma.user.findUnique({ where: { id: referrerId }, select: { id: true } }),
+    ])
+
+    if (!user || !referrer) {
+      return { success: false as const, reason: 'not_found' }
+    }
+
+    if (user.referredById) {
+      return { success: false as const, reason: 'already_set' }
+    }
+
+    const newUserBonus = REFERRAL_BONUS_FOR_FRIEND
+    const referrerBonus = REFERRAL_BONUS_FOR_REFERRER
+
+    await prisma.$transaction(async (tx) => {
+      const updated = await tx.user.updateMany({
+        where: { id: userId, referredById: null },
+        data: { referredById: referrerId, points: { increment: newUserBonus } },
+      })
+
+      if (updated.count === 0) {
+        throw new Error('ALREADY_SET')
+      }
+
+      await tx.user.update({
+        where: { id: referrerId },
+        data: { points: { increment: referrerBonus } },
+      })
+
+      await tx.pointsTransaction.create({
+        data: {
+          userId,
+          amount: newUserBonus,
+          type: 'REFERRAL',
+          description: 'Реферальний бонус (новий юзер)',
+          idempotencyKey: `ref-new-${userId}`,
+        },
+      })
+
+      await tx.pointsTransaction.create({
+        data: {
+          userId: referrerId,
+          amount: referrerBonus,
+          type: 'REFERRAL',
+          description: 'Реферальний бонус (запросив друга)',
+          idempotencyKey: `ref-referrer-${userId}`,
+        },
+      })
+    })
+
+    return { success: true as const }
+  }
+
   async function claimPendingLoyaltyEvents(userId: number, phone: string) {
     const pending = await prisma.pendingLoyaltyEvent.findMany({
       where: { phone, status: 'PENDING' },
@@ -212,25 +275,17 @@ export default async function authRoutes(app: FastifyInstance) {
         lastName: tgUser.last_name || null,
         username: tgUser.username || null,
         language: tgUser.language_code || 'uk',
-        referredById: referredById || null,
       },
     })
 
-    // Give referral bonus to new user (5 points)
-    if (referredById && user.createdAt.getTime() > Date.now() - 5000) {
-      await prisma.pointsTransaction.create({
-        data: {
-          userId: user.id,
-          amount: 5,
-          type: 'REFERRAL',
-          description: 'Бонус за реєстрацію за реферальним посиланням',
-          idempotencyKey: `referral-new-${user.id}`,
-        },
-      })
-      await prisma.user.update({
-        where: { id: user.id },
-        data: { points: { increment: 5 } },
-      })
+    if (referredById) {
+      try {
+        await applyReferralBonus(user.id, referredById)
+      } catch (error) {
+        if (!(error instanceof Error && error.message === 'ALREADY_SET')) {
+          throw error
+        }
+      }
     }
 
     // Generate JWT
@@ -314,46 +369,19 @@ export default async function authRoutes(app: FastifyInstance) {
       return reply.send({ success: false, reason: 'self_referral' })
     }
 
-    const user = await prisma.user.findUnique({ where: { telegramId } })
-    const referrer = await prisma.user.findUnique({ where: { telegramId: referrerTelegramId } })
-    if (!user || !referrer || user.referredById) {
-      return reply.send({ success: false, reason: 'already_set' })
+    const user = await prisma.user.findUnique({ where: { telegramId }, select: { id: true } })
+    const referrer = await prisma.user.findUnique({ where: { telegramId: referrerTelegramId }, select: { id: true } })
+    if (!user || !referrer) {
+      return reply.send({ success: false, reason: 'not_found' })
     }
 
-    const newUserBonus = 20
-    const referrerBonus = 20
-
     try {
-      await prisma.$transaction([
-        prisma.user.update({
-          where: { id: user.id },
-          data: { referredById: referrer.id, points: { increment: newUserBonus } },
-        }),
-        prisma.user.update({
-          where: { id: referrer.id },
-          data: { points: { increment: referrerBonus } },
-        }),
-        prisma.pointsTransaction.create({
-          data: {
-            userId: user.id,
-            amount: newUserBonus,
-            type: 'REFERRAL',
-            description: '\u0420\u0435\u0444\u0435\u0440\u0430\u043b\u044c\u043d\u0438\u0439 \u0431\u043e\u043d\u0443\u0441 (\u043d\u043e\u0432\u0438\u0439 \u044e\u0437\u0435\u0440)',
-            idempotencyKey: 'ref-new-' + user.id,
-          },
-        }),
-        prisma.pointsTransaction.create({
-          data: {
-            userId: referrer.id,
-            amount: referrerBonus,
-            type: 'REFERRAL',
-            description: '\u0420\u0435\u0444\u0435\u0440\u0430\u043b\u044c\u043d\u0438\u0439 \u0431\u043e\u043d\u0443\u0441 (\u0437\u0430\u043f\u0440\u043e\u0441\u0438\u0432 \u0434\u0440\u0443\u0433\u0430)',
-            idempotencyKey: 'ref-referrer-' + user.id,
-          },
-        }),
-      ])
-      return reply.send({ success: true })
+      const result = await applyReferralBonus(user.id, referrer.id)
+      return reply.send(result)
     } catch (error) {
+      if (error instanceof Error && error.message === 'ALREADY_SET') {
+        return reply.send({ success: false, reason: 'already_set' })
+      }
       return reply.status(500).send({ success: false, reason: (error as Error).message })
     }
   })

--- a/server/src/routes/game.ts
+++ b/server/src/routes/game.ts
@@ -17,7 +17,7 @@ const DAILY_GENERIC_GAME_LIMIT = 30
 const GAME_POINT_CAP_PER_DAY = 60
 
 const gameFinishSchema = z.object({
-  type: z.enum(['TIC_TAC_TOE', 'PERKIE_CATCH', 'BARISTA_RUSH', 'MEMORY_COFFEE', 'PERKIE_JUMP']),
+  type: z.enum(['TIC_TAC_TOE', 'MEMORY', 'QUIZ', 'WORD_PUZZLE', 'PERKIE_CATCH', 'BARISTA_RUSH', 'MEMORY_COFFEE', 'PERKIE_JUMP']),
   score: z.number().int().min(0).max(100000),
 })
 

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -132,4 +132,86 @@ export default async function healthRoutes(app: FastifyInstance) {
 
     return reply.send({ success: true, timestamp: new Date().toISOString(), results })
   })
+
+  // Poster integration health by location
+  app.get('/poster', async (_req, reply) => {
+    const locations = await prisma.location.findMany({
+      where: { isActive: true, hasPoster: true },
+      select: {
+        id: true,
+        slug: true,
+        name: true,
+        posterSubdomain: true,
+        posterToken: true,
+      },
+      orderBy: { id: 'asc' },
+    })
+
+    const checks = await Promise.all(locations.map(async (location) => {
+      if (!location.posterSubdomain) {
+        return {
+          slug: location.slug,
+          name: location.name,
+          status: 'error',
+          error: 'posterSubdomain_missing',
+        }
+      }
+      if (!location.posterToken) {
+        return {
+          slug: location.slug,
+          name: location.name,
+          status: 'error',
+          error: 'posterToken_missing',
+        }
+      }
+
+      const controller = new AbortController()
+      const timer = setTimeout(() => controller.abort(), 7000)
+      try {
+        const url = `https://${location.posterSubdomain}.joinposter.com/api/menu.getProducts?token=${location.posterToken}`
+        const res = await fetch(url, { signal: controller.signal })
+        if (!res.ok) {
+          return {
+            slug: location.slug,
+            name: location.name,
+            status: 'error',
+            error: `http_${res.status}`,
+          }
+        }
+        const data: any = await res.json()
+        const products = Array.isArray(data?.response) ? data.response.length : null
+        if (!Array.isArray(data?.response)) {
+          return {
+            slug: location.slug,
+            name: location.name,
+            status: 'error',
+            error: 'bad_response',
+          }
+        }
+        return {
+          slug: location.slug,
+          name: location.name,
+          status: 'ok',
+          products,
+        }
+      } catch (error: any) {
+        return {
+          slug: location.slug,
+          name: location.name,
+          status: 'error',
+          error: error?.name === 'AbortError' ? 'timeout' : (error?.message || 'fetch_failed'),
+        }
+      } finally {
+        clearTimeout(timer)
+      }
+    }))
+
+    const hasError = checks.some((c) => c.status !== 'ok')
+    return reply.status(hasError ? 503 : 200).send({
+      status: hasError ? 'degraded' : 'ok',
+      timestamp: new Date().toISOString(),
+      totalPosterLocations: locations.length,
+      checks,
+    })
+  })
 }

--- a/server/src/routes/loyalty.ts
+++ b/server/src/routes/loyalty.ts
@@ -4,6 +4,8 @@ import crypto from 'crypto'
 import { getLevel, getLevelMultiplier, getNextLevel } from '../lib/loyalty'
 
 const BOT = process.env.BOT_TOKEN || ''
+const REFERRAL_BONUS_FOR_FRIEND = 20
+const REFERRAL_BONUS_FOR_REFERRER = 20
 
 async function tgSend(chatId: string, text: string) {
   if (!BOT) return
@@ -86,6 +88,30 @@ export default async function loyaltyRoutes(app: FastifyInstance) {
     return reply.send({
       success: true, points, level, multiplier, nextLevel,
       spinsAvailable, completedOrders, transactions, vouchers,
+    })
+  })
+
+  app.get('/referral', { preHandler: requireAuth }, async (req: any, reply: any) => {
+    const user = await prisma.user.findUnique({
+      where: { id: req.user.id },
+      select: { id: true },
+    })
+    if (!user) return reply.status(404).send({ success: false, error: 'Not found' })
+
+    const invitedCount = await prisma.user.count({
+      where: { referredById: user.id },
+    })
+
+    const referralCode = `ref_${user.id}`
+    const referralLink = `https://t.me/${process.env.BOT_USERNAME || 'perkupbot'}?start=${referralCode}`
+
+    return reply.send({
+      success: true,
+      referralCode,
+      referralLink,
+      invitedCount,
+      bonusForFriend: REFERRAL_BONUS_FOR_FRIEND,
+      bonusForReferrer: REFERRAL_BONUS_FOR_REFERRER,
     })
   })
 

--- a/server/src/routes/menu.ts
+++ b/server/src/routes/menu.ts
@@ -7,6 +7,14 @@ import { buildMenuQrSvg, buildPrintableMenuHtml, groupProductsByCategory, sortMe
 
 const MENU_CACHE_TTL = 1800; // 30 хвилин
 
+function getPrimaryBadge(product: any): 'NEW' | 'TOP' | 'SEASONAL' | 'RECOMMENDED' | null {
+  if (product.isNew) return 'NEW'
+  if (product.isTop) return 'TOP'
+  if (product.isSeasonal) return 'SEASONAL'
+  if (product.isRecommended) return 'RECOMMENDED'
+  return null
+}
+
 function getBaseUrl(req: any) {
   const forwardedProto = String(req.headers['x-forwarded-proto'] || '').split(',')[0].trim()
   const protocol = forwardedProto || req.protocol || 'https'
@@ -78,6 +86,7 @@ export default async function menuRoutes(app: FastifyInstance) {
     products = products.map((p: any) => ({
       ...p,
       displayImageUrl: p.imageUrl || p.posterImageUrl || null,
+      primaryBadge: getPrimaryBadge(p),
     }))
 
     // Apply filters

--- a/server/src/routes/orders.ts
+++ b/server/src/routes/orders.ts
@@ -11,6 +11,7 @@ import { createPosterIncomingOrder } from '../services/poster'
 
 const OWNER_ID = process.env.OWNER_TELEGRAM_ID || ''
 const BOT = process.env.BOT_TOKEN || ''
+const NO_SHOW_BLOCK_THRESHOLD = 3
 
 async function tgSend(chatId: string, text: string) {
   if (!BOT || !chatId) return
@@ -88,6 +89,15 @@ export default async function orderRoutes(app: FastifyInstance) {
 
     const user: any = await prisma.user.findUnique({ where: { id: req.user.id } })
     if (!user) return reply.status(404).send({ success: false, error: 'User not found' })
+
+    const isPrivileged = ['ADMIN', 'OWNER'].includes(req.user.role)
+    if (!isPrivileged && user.cashPaymentBlocked && location.hasPoster && locationProfile.paymentFlow === 'CASHIER_ONLY') {
+      return reply.status(403).send({
+        success: false,
+        error: 'CASH_PAYMENT_BLOCKED',
+        message: 'Передзамовлення з оплатою на касі тимчасово обмежено. Зверніться до бариста або адміністратора.',
+      })
+    }
 
     let normalizedPhone: string | null = null
     if (location.hasPoster) {
@@ -449,5 +459,107 @@ export default async function orderRoutes(app: FastifyInstance) {
     }
 
     return reply.send({ success: true, status: parsed.data.status })
+  })
+
+  app.post('/:id/no-show', { preHandler: requireAuth }, async (req: any, reply: any) => {
+    if (!['BARISTA', 'ADMIN', 'OWNER'].includes(req.user.role)) {
+      return reply.status(403).send({ success: false, error: 'Forbidden' })
+    }
+
+    const id = Number(req.params.id)
+    const order = await prisma.order.findUnique({
+      where: { id },
+      include: { user: true, location: { select: { id: true, name: true, slug: true, hasPoster: true } } },
+    })
+    if (!order) return reply.status(404).send({ success: false, error: 'Not found' })
+    if (order.status === 'COMPLETED') {
+      return reply.status(400).send({ success: false, error: 'Cannot mark completed order as no-show' })
+    }
+    if (!order.location.hasPoster) {
+      return reply.status(400).send({ success: false, error: 'No-show flow is enabled only for Poster preorder locations' })
+    }
+
+    const markerKey = `no-show-order-${id}`
+    const existing = await prisma.pointsTransaction.findUnique({ where: { idempotencyKey: markerKey } })
+    if (existing) {
+      const currentUser = await prisma.user.findUnique({
+        where: { id: order.userId },
+        select: { id: true, noShowCount: true, cashPaymentBlocked: true },
+      })
+      return reply.send({
+        success: true,
+        alreadyMarked: true,
+        orderId: id,
+        threshold: NO_SHOW_BLOCK_THRESHOLD,
+        noShowCount: currentUser?.noShowCount ?? order.user.noShowCount,
+        cashPaymentBlocked: currentUser?.cashPaymentBlocked ?? order.user.cashPaymentBlocked,
+      })
+    }
+
+    try {
+      const result = await prisma.$transaction(async (tx: any) => {
+        await tx.pointsTransaction.create({
+          data: {
+            userId: order.userId,
+            amount: 0,
+            type: 'ADMIN',
+            description: `No-show mark for order #${id}`,
+            idempotencyKey: markerKey,
+          },
+        })
+
+        if (order.status !== 'CANCELLED') {
+          await tx.order.update({ where: { id }, data: { status: 'CANCELLED' } })
+        }
+
+        const updatedUser = await tx.user.update({
+          where: { id: order.userId },
+          data: { noShowCount: { increment: 1 } },
+          select: { id: true, noShowCount: true, cashPaymentBlocked: true, telegramId: true },
+        })
+
+        const shouldBlock = updatedUser.noShowCount >= NO_SHOW_BLOCK_THRESHOLD
+        if (shouldBlock && !updatedUser.cashPaymentBlocked) {
+          await tx.user.update({
+            where: { id: order.userId },
+            data: { cashPaymentBlocked: true },
+          })
+          updatedUser.cashPaymentBlocked = true
+        }
+
+        return updatedUser
+      })
+
+      if (result.telegramId) {
+        const msg = result.cashPaymentBlocked
+          ? `⚠️ Замовлення #${id} позначено як no-show. Передзамовлення з оплатою на касі тимчасово обмежено.`
+          : `⚠️ Замовлення #${id} позначено як no-show.`
+        await tgSend(String(result.telegramId), msg)
+      }
+
+      return reply.send({
+        success: true,
+        orderId: id,
+        threshold: NO_SHOW_BLOCK_THRESHOLD,
+        noShowCount: result.noShowCount,
+        cashPaymentBlocked: result.cashPaymentBlocked,
+      })
+    } catch (error: any) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+        const currentUser = await prisma.user.findUnique({
+          where: { id: order.userId },
+          select: { noShowCount: true, cashPaymentBlocked: true },
+        })
+        return reply.send({
+          success: true,
+          alreadyMarked: true,
+          orderId: id,
+          threshold: NO_SHOW_BLOCK_THRESHOLD,
+          noShowCount: currentUser?.noShowCount ?? order.user.noShowCount,
+          cashPaymentBlocked: currentUser?.cashPaymentBlocked ?? order.user.cashPaymentBlocked,
+        })
+      }
+      throw error
+    }
   })
 }


### PR DESCRIPTION
### Motivation

- Prevent crashes and aid debugging for the Fun/games route and collect runtime context when games render.  
- Unify game finish API and normalize various server/client game status shapes to be resilient to backend changes.  
- Add admin UX and server-side support for marking no-show orders, blocking cashier preorders after threshold, and a way to reset counts.  
- Expose/handle additional product marketing fields, Poster integration health checks and small UX/error improvements (checkout, order repeat). 

### Description

- Added a React error boundary and debug wrapper `GamesRouteBoundary` and wrapped the `/fun` route with `GamesRouteDebug` to log user/status/location and show a friendly message on render errors.  
- Renamed/centralized game finish client API to `gameApi.finish(...)` and updated game components (`MemoryGame`, `QuizGame`, `TicTacToe`, `WordPuzzle`) to call the new method; added `GameFinishType` typings and a server-side schema to accept the expanded list of game types.  
- Normalized game status shape on the client via `normalizeGameStatus` and added UI guards for missing/invalid status in `FunPage`.  
- Improved Telegram WebApp safe-calls in `main.tsx` to check function existence before calling.  
- Checkout error handling now surfaces `CASH_PAYMENT_BLOCKED` with a user-friendly message; server-side order creation checks `cashPaymentBlocked` and rejects cashier-only Poster preorders with an explicit `CASH_PAYMENT_BLOCKED` error.  
- Added a "Repeat order" action in `OrderStatusPage` which restores items, sets active location, and navigates to `/cart`.  
- Implemented no-show flow in server `orders` routes: `POST /api/orders/:id/no-show` marks order as no-show (idempotent), increments `noShowCount`, cancels the order if needed, and sets `cashPaymentBlocked` when threshold reached; added admin endpoint `POST /api/admin/users/:id/reset-no-show` to clear counters.  
- Centralized referral bonus logic in `auth` with `applyReferralBonus`, used on both widget login and bot-referral flow; added `GET /api/loyalty/referral` to expose referral info and bonuses.  
- Extended product/menu management: added marketing/product badge fields (`isHiddenInApp`, `isNew`, `isTop`, `isSeasonal`, `isRecommended`) to admin create/patch routes and derive `primaryBadge` for menu responses; tightened Poster editing restrictions to marketing fields only.  
- Added Poster integration health endpoint `GET /api/health/poster` to validate Poster subdomain/token and product responses, and added a QA script `server/scripts/qa-poster-webhook.ts` with `package.json` script `qa:poster-webhook`.  
- Small i18n addition (`order.repeat`) and other UI/UX tweaks such as loading/status messages in `FunPage`. 

### Testing

- Type-checked and built server artifacts during development (used the repository `build` flow) and updated TypeScript types for `gameApi.finish` and new route schemas.  
- Exercised the Poster webhook QA script via `server/scripts/qa-poster-webhook.ts` as a smoke test for webhook handling (script added for automated QA runs).  
- No new automated unit tests were added in this change; existing runtime and manual checks were performed on the client flows (`/fun`, checkout, order repeat) and server endpoints (`/api/game/*`, `/api/orders/:id/no-show`, `/api/admin/users/:id/reset-no-show`, `/api/health/poster`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb7f922124832892f099784cd86440)