### PR TITLE
poster: improve webhook cancellation handling, add fallback mapping, logging and docs

### DIFF
--- a/docs/poster-webhook-status-map.md
+++ b/docs/poster-webhook-status-map.md
@@ -1,0 +1,223 @@
+# Poster webhook status map (research/QA)
+
+## Scope
+
+This document captures **observed** Poster webhook payloads from test runs on **April 25, 2026** and defines how PerkUp should interpret them for status mapping.
+
+> This is a research/QA artifact. Do not change production runtime webhook logic based on this document alone.
+
+## Context
+
+Observed two real scenarios:
+
+1. Order created and then cancelled by barista on tablet.
+2. Order created, accepted, paid, and closed.
+
+Goal: map webhook events to safe PerkUp status handling and identify where API lookups are required.
+
+## Confirmed baseline (must remain unchanged)
+
+`transaction:closed` remains the primary and reliable payment source of truth.
+
+For matching active online orders:
+- set `COMPLETED`;
+- award points;
+- send Telegram receipt.
+
+If no active online order is found:
+- run offline loyalty flow;
+- fetch transaction details;
+- fetch client details;
+- resolve user by phone;
+- award points.
+
+Do not rewrite or weaken this payment/completed flow.
+
+## Legacy assumption vs observed reality
+
+### Legacy assumption (not confirmed by real payloads)
+
+```text
+incoming_order:changed + status=7
+-> set CANCELLED
+-> notify user
+```
+
+### Observed reality for this account
+
+```text
+transaction:changed
+transactions_history.type_history=changeorderstatus
+value=4
+value2=5
+
+incoming_order:changed
+data.type=1
+(no explicit status)
+```
+
+Conclusion: the legacy `incoming_order:changed + status=7` cancellation trigger is not confirmed for this Poster account.
+
+## Scenario A — created, then cancelled
+
+### 1) `transaction:added` with `type_history=open`
+
+Observed meaning:
+- Transaction opened in Poster.
+- **Not payment**.
+
+### 2) `incoming_order:added`
+
+Observed meaning:
+- Incoming order was created.
+- `data.type=1` observed, semantic meaning still needs confirmation.
+
+### 3) `transaction:changed` with `type_history=changeorderstatus`
+
+Observed values:
+- `value=4`
+- `value2=5`
+
+Observed meaning:
+- Key cancellation/status-change signal in this run.
+- Needs API confirmation (`transactions.getTransactionById`) before hard-mapping to `CANCELLED` in runtime logic.
+
+### 4) `incoming_order:changed`
+
+Observed meaning:
+- Event appears during barista cancellation flow.
+- Payload does not include explicit incoming order status (no confirmed `status:7` for this Poster account).
+- Use lookup/parsing strategy; payload alone is insufficient for definitive state.
+
+## Scenario B — created, accepted, paid, closed
+
+### 1) `transaction:added` with `type_history=open`
+
+Observed meaning:
+- Start/open of transaction.
+- **Not payment**.
+
+### 2) `incoming_order:added`
+
+Observed meaning:
+- Incoming order created.
+
+### 3) `transaction:changed` with `type_history=settable`
+
+Observed meaning:
+- Service event, likely acceptance/binding on tablet.
+- **Not payment**.
+
+### 4) `transaction:changed` with `type_history=changedeliveryinfo`
+
+Observed meaning:
+- Delivery metadata/service update.
+- **Not payment**.
+
+### 5) `incoming_order:changed`
+
+Observed meaning:
+- Likely acceptance/change by barista.
+- Payload still lacks explicit status field.
+
+### 6) `stock:changed`
+
+Observed meaning:
+- Inventory writeoff side effect.
+- Ignore for order lifecycle status.
+
+### 7) `transaction:closed` with `type_history=close`
+
+Observed meaning:
+- Paid and closed receipt.
+- **Primary source of truth for `COMPLETED`**.
+- `value2=1500` corresponds to amount (15.00).
+- Payment details present in `value_text.payments`.
+
+### 8) `incoming_order:closed`
+
+Observed meaning:
+- Arrives with/after payment closure.
+- Useful secondary signal, but not primary payment trigger.
+
+### 9) `client_payed_sum:changed`
+
+Observed meaning:
+- Customer paid sum updated.
+- Ignore for order lifecycle status.
+
+## Updated mapping table
+
+| Scenario | object | action | inner `type_history` | Observed values | Meaning | PerkUp action | Confidence |
+|---|---|---|---|---|---|---|---|
+| Transaction opened | transaction | added | open | `value4=2`, `status=0` in `value_text` | Transaction opened | Do not complete; optional logging | HIGH |
+| Incoming order created | incoming_order | added | - | `data.type=1` | Incoming order created | Optional `SENT_TO_POS/created` mark | HIGH |
+| Barista cancel/change | transaction | changed | changeorderstatus | `value=4`, `value2=5` | Observed cancel signal | Find linked active online order; set `CANCELLED` only if order is not `COMPLETED`; send cancel Telegram notification | MEDIUM |
+| Incoming order changed | incoming_order | changed | - | `data.type=1` (no explicit status) | Supplemental signal only | Do not map directly to `CANCELLED`/`ACCEPTED`; use only with safe lookup strategy | HIGH |
+| Barista accept/service updates | transaction | changed | settable / changedeliveryinfo | `user_id=5` in sample | Service transitions | Not a payment trigger | MEDIUM |
+| Stock writeoff | stock | changed | - | `value_relative=-1` | Inventory writeoff | Ignore for lifecycle status | HIGH |
+| Payment closed | transaction | closed | close | `payments.card=15`, `value2=1500` | Paid/closed transaction | `COMPLETED` + points + receipt | HIGH |
+| Incoming order closed | incoming_order | closed | - | `data.type=1` | Incoming order closed after payment | Secondary signal only | HIGH |
+| Client paid sum | client_payed_sum | changed | - | `value_absolute=15` | Paid amount aggregate update | Ignore for lifecycle status | HIGH |
+
+## Key conclusions
+
+1. `transaction:closed` is confirmed as the primary payment completion trigger.
+2. Poster emits many `transaction:changed` service events that must not be treated as payment status.
+3. Historical rule `incoming_order:changed + status:7 => CANCELLED` is not confirmed in current real payloads for this account.
+4. Observed cancel signal is `transaction:changed` with `type_history=changeorderstatus` and `value=4`, `value2=5`.
+5. `incoming_order:changed` without explicit status must not be mapped directly to `CANCELLED` or `ACCEPTED`.
+6. For reliable cancellation handling, safe linking/lookup is required between transaction/incoming order and PerkUp online order.
+7. `stock:changed` and `client_payed_sum:changed` should be ignored for order lifecycle status.
+
+## Why cancellation status previously did not update
+
+Previous runtime logic required this strict condition:
+
+```text
+posterStatus === 7 AND transaction_id is null
+```
+
+In real payloads for the affected account, cancellation can still carry a non-null `transaction_id`.  
+As a result, cancellation was skipped even when Poster status was cancellation-like.
+
+Hotfix rule:
+- `incoming_order:changed` + Poster lookup `status === 7` is sufficient to cancel (except terminal `COMPLETED`/`CANCELLED` orders).
+- Never roll back `COMPLETED`.
+- Add deterministic fallback from `transaction:changed` + `changeorderstatus` (`value=4`, `value2=5`) only when `incoming_order_id` can be resolved exactly.
+
+## Open technical questions
+
+1. Which Poster API endpoint is best for fetching canonical incoming order status after `incoming_order:changed`?
+2. Can `transaction:changed` + `type_history=changeorderstatus` + (`value=4`,`value2=5`) be safely treated as cancel across locations?
+3. Are there dedicated Poster events for `READY`/`PREPARING`, or should these remain local PerkUp states?
+4. Can `incoming_order.object_id` and `transaction.object_id` be linked reliably without additional lookup?
+
+## Runtime safety guards for follow-up implementation
+
+- Never roll back `COMPLETED` to `CANCELLED`.
+- Do not change `transaction:closed` payment logic.
+- Do not change offline loyalty flow triggered from `transaction:closed`.
+- If no safe deterministic link exists between Poster transaction and PerkUp online order, do not run fuzzy cancellation.
+
+## Target runtime logic for follow-up hotfix (documentation only)
+
+```text
+transaction:closed
+-> keep current payment/completed flow unchanged
+
+transaction:changed + type_history=changeorderstatus + value=4 + value2=5
+-> treat as observed cancel signal
+-> find linked active PerkUp online order
+-> if order is NOT COMPLETED, set CANCELLED
+-> send Telegram "❌ Order #X cancelled"
+
+incoming_order:changed without status
+-> do NOT map directly to CANCELLED or ACCEPTED
+-> use only as supplemental signal or as safe-lookup trigger
+```
+
+## Guardrail for implementation follow-up
+
+- This file is documentation only.
+- Runtime webhook changes for `ACCEPTED/CANCELLED/READY` must be implemented in a separate hotfix issue/PR.

--- a/server/src/routes/webhooks/poster.ts
+++ b/server/src/routes/webhooks/poster.ts
@@ -43,6 +43,29 @@ function buildReceipt(orderId: number, locationName: string, itemLines: string, 
   ].join('\n')
 }
 
+function toNum(v: any): number | null {
+  const n = Number(v)
+  return Number.isFinite(n) ? n : null
+}
+
+function extractDeterministicPosterOrderIdFromTransactionChanged(payload: any): number | null {
+  const candidates = [
+    payload?.incoming_order_id,
+    payload?.incomingOrderId,
+    payload?.data?.incoming_order_id,
+    payload?.data?.incomingOrderId,
+    payload?.value_text?.incoming_order_id,
+    payload?.value_text?.incomingOrderId,
+    payload?.transactions_history?.incoming_order_id,
+    payload?.transactions_history?.incomingOrderId,
+  ]
+  for (const c of candidates) {
+    const parsed = toNum(c)
+    if (parsed && parsed > 0) return parsed
+  }
+  return null
+}
+
 async function findUserByPosterTransaction(subdomain: string, token: string, transactionId: number, log: any): Promise<{ normalizedPhone: string | null; userId: number | null; telegramId: bigint | null }> {
   try {
     const url = 'https://' + subdomain + '.joinposter.com/api/transactions.getTransactionById?token=' + token + '&transaction_id=' + transactionId
@@ -152,17 +175,59 @@ export default async function posterWebhookRoutes(app: FastifyInstance) {
     reply.send({ success: true })
 
     const p = req.body as any
-    app.log.info({ object: p.object, action: p.action, object_id: p.object_id, account: p.account }, 'Poster webhook received')
+    app.log.info({
+      event: 'POSTER_WEBHOOK_INTAKE',
+      object: p?.object || null,
+      action: p?.action || null,
+      object_id: p?.object_id ?? null,
+      account: p?.account || null,
+      hasAccount: Boolean(p?.account),
+      hasObjectId: p?.object_id !== undefined && p?.object_id !== null,
+    }, 'POSTER_WEBHOOK_INTAKE')
 
-    if (!p.account || !p.object_id) return
+    if (!p.account || !p.object_id) {
+      app.log.info({
+        event: 'POSTER_BRANCH_IGNORED',
+        reason: 'missing_account_or_object_id',
+        object: p?.object || null,
+        action: p?.action || null,
+        account: p?.account || null,
+        object_id: p?.object_id ?? null,
+      }, 'POSTER_BRANCH_IGNORED')
+      return
+    }
 
     const location = await prisma.location.findFirst({
       where: { posterSubdomain: p.account, hasPoster: true },
     })
-    if (!location) { app.log.warn({ account: p.account }, 'Location not found'); return }
+    app.log.info({
+      event: 'POSTER_WEBHOOK_LOCATION_MATCH',
+      account: p.account,
+      matched: Boolean(location),
+      locationId: location?.id || null,
+      locationSlug: location?.slug || null,
+      hasPoster: location?.hasPoster || false,
+    }, 'POSTER_WEBHOOK_LOCATION_MATCH')
+    if (!location) {
+      app.log.warn({
+        event: 'POSTER_BRANCH_IGNORED',
+        reason: 'location_not_found',
+        account: p.account,
+        object: p.object,
+        action: p.action,
+        object_id: p.object_id,
+      }, 'POSTER_BRANCH_IGNORED')
+      return
+    }
 
     // TRANSACTION CLOSED = paid
     if (p.object === 'transaction' && p.action === 'closed') {
+      app.log.info({
+        event: 'POSTER_BRANCH_TRANSACTION_CLOSED',
+        account: p.account,
+        object_id: p.object_id,
+        locationId: location.id,
+      }, 'POSTER_BRANCH_TRANSACTION_CLOSED')
       app.log.info({ transactionId: p.object_id }, 'Transaction CLOSED = PAID')
 
       // First: check for online order
@@ -256,6 +321,12 @@ export default async function posterWebhookRoutes(app: FastifyInstance) {
 
     // INCOMING ORDER CHANGED = status change
     if (p.object === 'incoming_order' && p.action === 'changed') {
+      app.log.info({
+        event: 'POSTER_BRANCH_INCOMING_ORDER_CHANGED',
+        account: p.account,
+        object_id: p.object_id,
+        locationId: location.id,
+      }, 'POSTER_BRANCH_INCOMING_ORDER_CHANGED')
       if (!location.posterToken) return
 
       const posterOrderId = Number(p.object_id)
@@ -263,8 +334,6 @@ export default async function posterWebhookRoutes(app: FastifyInstance) {
         where: { posterOrderId, locationId: location.id },
         include: { user: true },
       })
-      if (!order) { app.log.warn({ posterOrderId }, 'Order not found'); return }
-      if (['CANCELLED', 'COMPLETED'].includes(order.status)) return
 
       try {
         const url = 'https://' + p.account + '.joinposter.com/api/incomingOrders.getIncomingOrder?token=' + location.posterToken + '&incoming_order_id=' + posterOrderId
@@ -272,15 +341,30 @@ export default async function posterWebhookRoutes(app: FastifyInstance) {
         const data = await res.json() as any
         const posterStatus = Number(data?.response?.status ?? 0)
         const transactionId = data?.response?.transaction_id
-        app.log.info({ posterStatus, transactionId, orderId: order.id }, 'Poster incoming_order status')
+        app.log.info({
+          posterOrderId,
+          perkupOrderFound: Boolean(order),
+          currentOrderStatus: order?.status || null,
+          posterStatus,
+          transactionId,
+        }, 'Poster incoming_order changed lookup')
 
-        if (posterStatus === 7 && !transactionId) {
+        if (!order) {
+          app.log.warn({ posterOrderId, posterStatus, transactionId }, 'PerkUp order not found for incoming_order changed')
+          return
+        }
+        if (['CANCELLED', 'COMPLETED'].includes(order.status)) {
+          app.log.info({ orderId: order.id, currentOrderStatus: order.status }, 'Skipping incoming_order change for terminal order')
+          return
+        }
+
+        if (posterStatus === 7) {
           await prisma.order.update({ where: { id: order.id }, data: { status: 'CANCELLED' } })
           await tgSend(String(order.user.telegramId), [
             '\u274c *\u0417\u0430\u043c\u043e\u0432\u043b\u0435\u043d\u043d\u044f #' + order.id + ' \u0441\u043a\u0430\u0441\u043e\u0432\u0430\u043d\u043e*',
             '\u0411\u0430\u0440\u0438\u0441\u0442\u0430 \u0432\u0456\u0434\u043c\u0456\u043d\u0438\u0432 \u0437\u0430\u043c\u043e\u0432\u043b\u0435\u043d\u043d\u044f. \u042f\u043a\u0449\u043e \u0446\u0435 \u043f\u043e\u043c\u0438\u043b\u043a\u0430 \u2014 \u0437\u0432\u0435\u0440\u043d\u0456\u0442\u044c\u0441\u044f \u0434\u043e \u0431\u0430\u0440\u0438\u0441\u0442\u0438.',
           ].join('\n'))
-          app.log.info({ orderId: order.id }, 'Order CANCELLED')
+          app.log.info({ orderId: order.id, posterOrderId, posterStatus, transactionId }, 'Order CANCELLED from incoming_order status=7')
         } else if (posterStatus === 2 && order.status === 'SENT_TO_POS') {
           await prisma.order.update({ where: { id: order.id }, data: { status: 'ACCEPTED' } })
           await tgSend(String(order.user.telegramId), [
@@ -311,8 +395,84 @@ export default async function posterWebhookRoutes(app: FastifyInstance) {
       return
     }
 
+    // TRANSACTION CHANGED (changeorderstatus) = fallback cancel signal
+    if (p.object === 'transaction' && p.action === 'changed') {
+      app.log.info({
+        event: 'POSTER_BRANCH_TRANSACTION_CHANGED',
+        account: p.account,
+        object_id: p.object_id,
+        locationId: location.id,
+        type_history: p?.transactions_history?.type_history || p?.data?.type_history || null,
+      }, 'POSTER_BRANCH_TRANSACTION_CHANGED')
+      const historyType = String(p?.transactions_history?.type_history || p?.data?.type_history || '')
+      const value = toNum(p?.transactions_history?.value ?? p?.value)
+      const value2 = toNum(p?.transactions_history?.value2 ?? p?.value2)
+
+      if (historyType !== 'changeorderstatus' || value !== 4 || value2 !== 5) return
+
+      const posterOrderId = extractDeterministicPosterOrderIdFromTransactionChanged(p)
+      if (!posterOrderId) {
+        app.log.info({
+          transactionId: p.object_id,
+          historyType,
+          value,
+          value2,
+        }, 'Skip fallback cancel: no deterministic incoming_order_id in transaction payload')
+        return
+      }
+
+      const order = await prisma.order.findFirst({
+        where: { posterOrderId, locationId: location.id },
+        include: { user: true },
+      })
+      if (!order) {
+        app.log.warn({ posterOrderId, transactionId: p.object_id }, 'Skip fallback cancel: PerkUp order not found')
+        return
+      }
+      if (['CANCELLED', 'COMPLETED'].includes(order.status)) {
+        app.log.info({ orderId: order.id, currentOrderStatus: order.status }, 'Skip fallback cancel: order already terminal')
+        return
+      }
+
+      await prisma.order.update({ where: { id: order.id }, data: { status: 'CANCELLED' } })
+      await tgSend(String(order.user.telegramId), [
+        '\u274c *\u0417\u0430\u043c\u043e\u0432\u043b\u0435\u043d\u043d\u044f #' + order.id + ' \u0441\u043a\u0430\u0441\u043e\u0432\u0430\u043d\u043e*',
+        '\u0411\u0430\u0440\u0438\u0441\u0442\u0430 \u0432\u0456\u0434\u043c\u0456\u043d\u0438\u0432 \u0437\u0430\u043c\u043e\u0432\u043b\u0435\u043d\u043d\u044f. \u042f\u043a\u0449\u043e \u0446\u0435 \u043f\u043e\u043c\u0438\u043b\u043a\u0430 \u2014 \u0437\u0432\u0435\u0440\u043d\u0456\u0442\u044c\u0441\u044f \u0434\u043e \u0431\u0430\u0440\u0438\u0441\u0442\u0438.',
+      ].join('\n'))
+      app.log.info({ orderId: order.id, posterOrderId, transactionId: p.object_id }, 'Order CANCELLED from transaction changeorderstatus fallback')
+      return
+    }
+
     if (p.object === 'incoming_order' && p.action === 'added') {
       app.log.info({ posterOrderId: p.object_id }, 'incoming_order added - already tracked')
+      app.log.info({
+        event: 'POSTER_BRANCH_IGNORED',
+        reason: 'incoming_order_added',
+        account: p.account,
+        object_id: p.object_id,
+        locationId: location.id,
+      }, 'POSTER_BRANCH_IGNORED')
+      return
     }
+
+    if (p.object === 'incoming_order' && p.action === 'closed') {
+      app.log.info({
+        event: 'POSTER_BRANCH_INCOMING_ORDER_CLOSED',
+        account: p.account,
+        object_id: p.object_id,
+        locationId: location.id,
+      }, 'POSTER_BRANCH_INCOMING_ORDER_CLOSED')
+      return
+    }
+
+    app.log.info({
+      event: 'POSTER_BRANCH_IGNORED',
+      reason: 'no_matching_branch',
+      account: p.account,
+      object: p.object,
+      action: p.action,
+      object_id: p.object_id,
+      locationId: location.id,
+    }, 'POSTER_BRANCH_IGNORED')
   })
 }


### PR DESCRIPTION
### Motivation

- Fix missed cancellation detection caused by varying Poster webhook payload shapes and add deterministic fallback logic to safely map cancels to PerkUp orders.  
- Improve observability and runtime safety guards to avoid rolling back `COMPLETED` and to make webhook processing decisions auditable.  
- Capture research findings about Poster webhook semantics in a dedicated document for follow-up hotfix work.

### Description

- Add research documentation `docs/poster-webhook-status-map.md` that summarizes observed Poster webhook payloads, recommended mapping rules, and open questions.  
- Add helper utilities `toNum` and `extractDeterministicPosterOrderIdFromTransactionChanged` to parse numeric IDs from heterogeneous transaction payloads.  
- Harden `server/src/routes/webhooks/poster.ts` with structured logging events, early-ignore branches for missing `account`/`object_id` and unmatched locations, and more informative logs for key branches.  
- Preserve existing `transaction:closed` payment/completed flow and keep offline loyalty behavior unchanged, while updating `incoming_order:changed` to fetch canonical status via Poster API and cancel when `posterStatus === 7` (removing the previous `transaction_id`-null requirement), and add a safe fallback that treats `transaction:changed` + `type_history=changeorderstatus` + `value=4` + `value2=5` as a cancel only when a deterministic `incoming_order_id` can be extracted and mapped to a PerkUp order.

### Testing

- Ran the backend test suite including existing unit tests and linter checks and the run completed successfully.  
- Performed smoke/integration validation by replaying sample webhook payloads from research runs to verify `transaction:closed` completion and the new cancellation handling via `incoming_order` lookup and `transaction.changed` fallback, and observed expected transitions.  
- No automated regressions detected in webhook branches covered by the existing tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec6150df388328af37b6739979b7da)